### PR TITLE
fix(stream): rewrite RTSP host to 127.0.0.1 for all local MediaMTX co…

### DIFF
--- a/app/services/stream/service.py
+++ b/app/services/stream/service.py
@@ -37,13 +37,9 @@ def _rewrite_rtsp_url(url: str, proxy_port: int, internal_port: int) -> str:
     if parsed.port != proxy_port:
         return url
 
-    # Windows 上 localhost 可能解析为 ::1（IPv6），但 MediaMTX 只绑 127.0.0.1（IPv4）
-    host = parsed.hostname or ""
-    if host.lower() == "localhost":
-        host = "127.0.0.1"
-    # IPv6 literal 在 URL authority 中需用方括号包裹，如 [::1]:port
-    host_in_netloc = f"[{host}]" if ":" in host else host
-    new_netloc = f"{host_in_netloc}:{internal_port}"
+    # 端口匹配说明目标是本机 MediaMTX，统一改写为 127.0.0.1
+    # （覆盖 localhost / 外网 IP / 任意 host，避免流量绕道外网网卡被 iptables 拦截）
+    new_netloc = f"127.0.0.1:{internal_port}"
     if parsed.username:
         creds = parsed.username
         if parsed.password:

--- a/docs/RTSP_FLOW.md
+++ b/docs/RTSP_FLOW.md
@@ -1,6 +1,6 @@
 # RTSP 全流程调用说明（CleanSightBackend）
 
-> **版本**: 2.1（2026-04-14 更新）
+> **版本**: 2.2（2026-04-16 更新）
 
 ## 概述
 
@@ -30,7 +30,7 @@
 ```
 
 - **对外**：MediaMTX 的 RTSP 端口 8004 由 [mediamtx_gateway](../mediamtx_gateway/) 反代，原始 MediaMTX 只监听 `127.0.0.1:18004`。
-- **后端拉流**：`start_stream()` 中的 `_rewrite_rtsp_url()` 会自动把 URL 中的 8004 端口重写为 18004，绕过代理直连 MediaMTX（避免自我 IP 被代理误封）。
+- **后端拉流**：`start_stream()` 中的 `_rewrite_rtsp_url()` 会自动把端口 8004 重写为 18004，并将 host **统一替换为 `127.0.0.1`**（无论客户端传入的是 `localhost`、外网 IP 还是其他地址），确保 FFmpeg 始终走 loopback 直连 MediaMTX，不经过外网网卡。
 - **Gateway 部署**：生产建议 `mediamtx_bin` 留空让 MediaMTX 由 systemd/容器独立管理；开发可填写 bin 路径由 Gateway 守护。详见 [API_GATEWAY.md](API_GATEWAY.md)。
 
 ## 流路径命名约定（隐式耦合说明）
@@ -174,7 +174,7 @@ ffmpeg -an -re -stream_loop -1 -i test_video.mp4 \
 - **推流端被网关封禁**：查看后端日志 `[RTSPProxy] Blocked ... <ip>`；调整 `mediamtx_gateway/config.ini` 的 `allowed_ips`、`rate_limit`，或等待 `ban_duration`（默认 3600s）过期。
 - **后端拉流失败**：查看 FFmpeg stderr（decoder 已按瞬态 vs 真实崩溃分类打日志）；确认 rtsp_url 的端口与 `CLEANSIGHT_MEDIAMTX_PROXY_PORT` 一致（默认 8004）。
 - **`/api/start` 返回 409**：`client_id` 已有存活流，先调 `/api/terminate`。
-- **IPv6 / localhost 问题**：Windows 下 `localhost` 可能解析为 `::1`，MediaMTX 只绑 127.0.0.1；代码已在 URL 重写时自动把 `localhost` 替换为 `127.0.0.1`，外部调用端仍建议使用 IPv4 地址。
+- **host 被重写为 127.0.0.1**：`_rewrite_rtsp_url()` 在端口匹配时会将任意 host（`localhost`、外网 IP 等）统一改写为 `127.0.0.1`。这是预期行为——后端拉流目标始终是本机 MediaMTX，走 loopback 可绕过云服务器 iptables 对 UDP 高位端口的拦截。`/api/start` 的 `rtsp_url` 传外网 IP 或 localhost 均可，rewrite 会统一处理。
 
 ## 相关文档
 

--- a/integration_tests/test_single_client.py
+++ b/integration_tests/test_single_client.py
@@ -54,15 +54,13 @@ RECONNECT_SUCCESS_TIMEOUT = 45
 def build_urls(server: str, client_id: str) -> tuple:
     """
     返回 (push_url, pull_url)。
-    push_url: FFmpeg 推流目标（用服务器 IP，远程时为服务器公网地址）
-    pull_url: /api/start 传的 RTSP 地址（后端始终从自己的 localhost 拉流）
+    push_url == pull_url：推流目标即后端拉流地址，后端内部会 rewrite 为 127.0.0.1。
     """
     # Windows 上 localhost 可能解析为 ::1（IPv6），但 RTSPProxy 只监听 IPv4。
     # 本地推流强制用 127.0.0.1；远程推流保留原始 server 地址。
     push_host = "127.0.0.1" if server in ("localhost", "127.0.0.1") else server
     push_url = f"rtsp://{push_host}:8004/live/{client_id}"
-    pull_url = f"rtsp://localhost:8004/live/{client_id}"
-    return push_url, pull_url
+    return push_url, push_url
 
 
 @contextmanager


### PR DESCRIPTION
…nnections

_rewrite_rtsp_url() previously only fixed 'localhost' → '127.0.0.1', leaving external IPs (e.g. 106.75.229.120) unchanged after port rewrite. FFmpeg would connect via the external NIC, where cloud server iptables blocks inbound UDP on ephemeral RTP ports, causing all reconnect attempts to produce zero frames.

Fix: when proxy_port matches, unconditionally set host to 127.0.0.1 — pulling is always from the local MediaMTX, so loopback is always correct regardless of what host the client provides.

Also fix integration test: build_urls() now passes push_url as pull_url (the URL the client pushes to is exactly what the backend should pull from), so the test exercises the full rewrite path instead of bypassing it with a hardcoded internal address.