### PR TITLE
Refact/feature layer

### DIFF
--- a/app/domain/detection.py
+++ b/app/domain/detection.py
@@ -32,3 +32,15 @@ class FrameDetections:
     timestamp: float  # 时间戳
     success: bool = True  # 推理是否成功
     error: Optional[str] = None  # 错误信息（失败时提供）
+
+
+@dataclass
+class FrameFeature:
+    """一帧多流对齐的检测记录（特征层输入）：ts + {流名: FrameDetections}。
+
+    online 写回口物化、offline 回放重建；不含 cq，可跨 client/inference/offline 复用。
+    注：持有的是对齐后的检测（非计算特征），特征张量化仍在算子内（下一步共享）。
+    """
+
+    ts: float  # 帧捕获时间戳（= 各流 FrameDetections.timestamp）
+    by_source: Dict[str, FrameDetections]  # {流名(detector.name): 该流当帧检测}

--- a/app/domain/detection.py
+++ b/app/domain/detection.py
@@ -44,3 +44,7 @@ class FrameFeature:
 
     ts: float  # 帧捕获时间戳（= 各流 FrameDetections.timestamp）
     by_source: Dict[str, FrameDetections]  # {流名(detector.name): 该流当帧检测}
+    # 帧分辨率：fan-out 前定死的每帧常量（同帧各流同值），由 pool 从原始帧盖章、写回口物化带入；
+    # 供归一化/空间还原按真实尺寸换算。拆两字段（非 (w,h) 元组）避免隐式序混淆。缺省 None → 走默认兜底。
+    frame_width: Optional[int] = None
+    frame_height: Optional[int] = None

--- a/app/services/client/queues.py
+++ b/app/services/client/queues.py
@@ -9,17 +9,17 @@ import enum
 import threading
 import time
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Deque, Dict, List, Optional, Tuple
 
 import numpy as np
 
 from app.domain.alarm import Alarm
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameFeature
 from app.domain.frame import Frame
 from app.utils.metrics import frame_drop_total
 
-if TYPE_CHECKING:
-    from app.services.inference.models import FrameInference
+# signals_10s 聚合底线（固定 10s），与帧窗保留时长（可 ≥10s）解耦。
+_SIGNALS_WINDOW_SEC = 10.0
 
 
 class RunState(enum.Enum):
@@ -31,7 +31,7 @@ class RunState(enum.Enum):
 
     门控在写入**时刻**判 state（非 dispatch 时刻）：迟到写落到 DRAINING/CLOSED 的旧 CQ 被拒，
     不串台到新 run。状态读免锁（枚举原子读 + 单调）；`_state_lock` 仅串行/幂等转换本身，
-    绝不与 7 把 payload 锁互嵌——无新锁环。
+    绝不与 6 把 payload 锁互嵌——无新锁环。
     """
 
     ACTIVE = "ACTIVE"
@@ -53,7 +53,6 @@ class ClientQueues:
     - 默认 CA 队列最大长度为 2700 帧，约 90 秒的视频缓存（30fps）
 
     锁清单（Lock Inventory）：
-      _task_lock        Lock   （历史）保留于全清顺序；task/task_id/step_id/stage 现为不可变身份，读免锁
       ca_ready          无锁   SPSC deque：单生产者 decoder / 单消费者 dispatcher，GIL 保证原子性
       _raw_lock         Lock   ca_raw + latest_raw_frame + latest_raw_timestamp
       _viz_lock         Lock   ca_processed + _latest_rendered（VizWorker 对同帧连续写两者）
@@ -63,7 +62,7 @@ class ClientQueues:
       _alarm_lock       Lock   _alarm_log + _alarm_seq + _alarm_gate（告警生命周期）
 
     全清顺序（clear() 同时持锁时的固定顺序，防死锁）：
-      _task_lock → _raw_lock → _viz_lock → _inference_lock
+      _raw_lock → _viz_lock → _inference_lock
       → _frontend_lock → _slide_window_lock → _alarm_lock
 
     身份（task_id/step_id/source_ip/stage）为构造定死的不可变 primitive，热路径免锁直读。
@@ -98,7 +97,6 @@ class ClientQueues:
         self._decimate_phase: int = 0
 
         # --- 锁声明（顺序同 Lock Inventory 全清顺序）---
-        self._task_lock = threading.Lock()       # (历史)保留于全清顺序；身份已不可变、读免锁
         self._raw_lock = threading.Lock()        # ca_raw + 帧缓存
         self._viz_lock = threading.Lock()        # ca_processed + _latest_rendered
         self._inference_lock = threading.Lock()  # _latest_inference
@@ -106,7 +104,7 @@ class ClientQueues:
         self._slide_window_lock = threading.Lock()
         self._alarm_lock = threading.Lock()      # _alarm_log + _alarm_seq + _alarm_gate
 
-        # 运行状态机的锁（独立于下方 7 把 payload 锁：只串行/幂等本状态转换，
+        # 运行状态机的锁（独立于下方 6 把 payload 锁：只串行/幂等本状态转换，
         # 从不与任何 payload 锁互嵌，故不引入新锁环——见 RunState docstring）
         self._state: RunState = RunState.ACTIVE
         self._state_lock = threading.Lock()
@@ -147,16 +145,15 @@ class ClientQueues:
         # 最新渲染帧（单槽位，由 _viz_lock 保护，供前端 WebSocket 实时推流）
         self._latest_rendered: Optional[Frame] = None
 
-        # 最新推理结果原子快照（由 _inference_lock 保护）
-        self._latest_inference: Optional[FrameInference] = None
+        # 最新推理快照：帧级 FrameFeature（由 _inference_lock 保护，供 Viz 原子读同帧一致）
+        self._latest_inference: Optional[FrameFeature] = None
 
-        # 滑动窗口：per-stream(detector.name) 检测环形缓冲（由 _slide_window_lock 保护）
-        self._slide_window: Dict[str, Deque[FrameDetections]] = {}
-        # 缓冲保留时长底线（保证 signals_10s 仍见 10s）；感受野只向上扩展，不缩短。
-        self._slide_window_seconds: float = 10.0
-        # per-stream 感受野覆盖：{流名: 订阅该流的算子最大 window_seconds}，由 set_stream_windows 配置。
-        # 实际保留时长 = max(底线, 该流感受野)。
-        self._stream_windows: Dict[str, float] = {}
+        # 滑动窗口：帧级 FrameFeature 环形缓冲（一帧一条，多流已对齐，由 _slide_window_lock 保护）。
+        # 写回口物化 FrameFeature 后单次 push_detection；算子/ signals 统一从此读，无需按 ts 拼帧。
+        self._slide_window: Deque[FrameFeature] = deque()
+        # 帧窗保留时长（秒）：= max(_SIGNALS_WINDOW_SEC 底线, 各算子最大感受野)，由 set_stream_windows 配置。
+        # 只向上扩展；signals_10s 聚合另按固定 10s 底线裁窗，二者解耦。
+        self._slide_window_seconds: float = _SIGNALS_WINDOW_SEC
 
         # 最新时序事件列表（由 _frontend_lock 保护，与 _stage 合并）
         self._latest_temporal: List[str] = []
@@ -257,8 +254,8 @@ class ClientQueues:
 
     # --- latest_inference 操作（原子推理快照）---
 
-    def set_latest_inference(self, result: "FrameInference") -> None:
-        """原子写入最新推理结果（由 InferenceLoop 调用）。
+    def set_latest_inference(self, result: FrameFeature) -> None:
+        """原子写入最新推理快照 FrameFeature（由 InferenceLoop 调用）。
 
         写门：非 ACTIVE 拒——迟到推理结果落到旧 CQ 被拒，不串台。
         """
@@ -267,7 +264,7 @@ class ClientQueues:
         with self._inference_lock:
             self._latest_inference = result
 
-    def get_latest_inference(self) -> Optional["FrameInference"]:
+    def get_latest_inference(self) -> Optional[FrameFeature]:
         """原子读取最新推理结果（由 VisualizationWorker 调用）。"""
         with self._inference_lock:
             return self._latest_inference
@@ -356,13 +353,13 @@ class ClientQueues:
         self.close()
 
     def _release_payload(self) -> None:
-        """原子释放所有队列和重数据缓存（按全清顺序持 7 把 payload 锁）。
+        """原子释放所有队列和重数据缓存（按全清顺序持 6 把 payload 锁）。
 
         身份（task/task_id/step_id/source_ip/stage）不可变，不在此重置——仅释放
         payload（帧/滑窗/告警/快照）回收内存（尤其大块 numpy 帧）。
         """
         locks = [
-            self._task_lock, self._raw_lock, self._viz_lock,
+            self._raw_lock, self._viz_lock,
             self._inference_lock, self._frontend_lock,
             self._slide_window_lock, self._alarm_lock,
         ]
@@ -392,40 +389,35 @@ class ClientQueues:
     # --- slide_window 操作 ---
 
     def set_stream_windows(self, windows: Dict[str, float]) -> None:
-        """配置 per-stream 感受野（{流名: 最大 window_seconds}），整体替换。
+        """配置帧窗保留时长 = max(10s 底线, 各算子最大感受野)。
 
-        由 InferenceManager 在算子实例化后调用：缓冲保留时长取
-        max(底线 10s, 该流感受野)，故感受野只向上扩展，signals_10s 的 10s 不受影响。
+        由 InferenceManager 在算子实例化后调用（入参 {流名: 最大 window_seconds}）：
+        单条帧窗保留所有算子里最长的感受野，各算子自行 _clip 到自身 window_seconds；
+        感受野只向上扩展，signals_10s 另按固定 10s 底线裁窗，不受影响。
         """
         with self._slide_window_lock:
-            self._stream_windows = dict(windows)
+            self._slide_window_seconds = max(
+                [_SIGNALS_WINDOW_SEC] + list(windows.values())
+            )
 
-    def push_detection(self, task_name: str, output: FrameDetections) -> None:
-        """将 FrameDetections 追加到 per-stream 滑动窗口，按感受野自动淘汰过期条目。
+    def push_detection(self, feature: FrameFeature) -> None:
+        """将一帧对齐后的 FrameFeature 追加到帧窗，按保留时长淘汰过期条目。
 
-        写门：非 ACTIVE 拒——迟到检测写回落到旧 CQ 被拒。
+        写回口一帧一次（多流已在 FrameFeature.by_source 内对齐），不再逐 detector。
+        写门：非 ACTIVE 拒——迟到写回落到旧 CQ 被拒。
         """
         if self._state is not RunState.ACTIVE:
             return
         with self._slide_window_lock:
-            if task_name not in self._slide_window:
-                self._slide_window[task_name] = deque()
-            window = self._slide_window[task_name]
-            window.append(output)
-            retain = max(
-                self._slide_window_seconds, self._stream_windows.get(task_name, 0.0)
-            )
-            cutoff = output.timestamp - retain
-            while window and window[0].timestamp < cutoff:
-                window.popleft()
+            self._slide_window.append(feature)
+            cutoff = feature.ts - self._slide_window_seconds
+            while self._slide_window and self._slide_window[0].ts < cutoff:
+                self._slide_window.popleft()
 
-    def get_slide_window(self, task_name: str) -> List[FrameDetections]:
-        """返回指定 task 滑动窗口的快照副本（线程安全）。"""
+    def get_slide_window(self) -> List[FrameFeature]:
+        """返回帧窗的快照副本（线程安全）；每条 = 一帧多流对齐检测。"""
         with self._slide_window_lock:
-            window = self._slide_window.get(task_name)
-            if not window:
-                return []
-            return list(window)
+            return list(self._slide_window)
 
     # --- latest_temporal 操作 ---
 
@@ -492,19 +484,28 @@ class ClientQueues:
         {stream_name: {"active": bool, "hit_count": int, "max_conf": float}}
         —— 只按流名聚合，不做流名→metric 映射（那是 inference 展示知识，归 router 装配）。
         """
-        summary: Dict[str, Dict[str, Any]] = {}
+        acc: Dict[str, Dict[str, float]] = {}
         with self._slide_window_lock:
-            for task_name, window in self._slide_window.items():
-                hit_count = 0
-                max_conf = 0.0
-                for output in window:
-                    if output.detections:
-                        hit_count += 1
-                        frame_max_conf = max(d.confidence for d in output.detections)
-                        max_conf = max(max_conf, frame_max_conf)
-                summary[task_name] = {
-                    "active": hit_count > 0,
-                    "hit_count": hit_count,
-                    "max_conf": round(float(max_conf), 4),
-                }
-        return summary
+            if not self._slide_window:
+                return {}
+            # signals_10s 固定按 10s 底线裁窗（帧窗可保留更长感受野，此处不受影响）。
+            cutoff = self._slide_window[-1].ts - _SIGNALS_WINDOW_SEC
+            for feat in self._slide_window:
+                if feat.ts < cutoff:
+                    continue
+                for src, fd in feat.by_source.items():
+                    if fd is None:
+                        continue
+                    a = acc.setdefault(src, {"hit": 0.0, "max_conf": 0.0})
+                    if fd.detections:
+                        a["hit"] += 1
+                        frame_max_conf = max(d.confidence for d in fd.detections)
+                        a["max_conf"] = max(a["max_conf"], frame_max_conf)
+        return {
+            src: {
+                "active": a["hit"] > 0,
+                "hit_count": int(a["hit"]),
+                "max_conf": round(float(a["max_conf"]), 4),
+            }
+            for src, a in acc.items()
+        }

--- a/app/services/inference/detection/detector.py
+++ b/app/services/inference/detection/detector.py
@@ -48,8 +48,9 @@ class Detector(ABC):
             frames: BGR 图像列表
             timestamps: 各帧的帧捕获时间戳（真值锚点，源自 Frame.timestamp）。
                 实现须把 timestamps[i] 原样写入 frames[i] 对应的
-                FrameDetections.timestamp——下游 _zip_by_ts 按此对齐多流，
-                detector 不得自造时间戳（否则同帧多流 ts 不等会漏帧）。
+                FrameDetections.timestamp——写回口据此物化 FrameFeature（帧级多流对齐），
+                帧窗算子用 FrameFeature.ts 裁窗、用 FrameDetections.timestamp 推进游标，
+                二者须同源同值；detector 不得自造时间戳（否则内部对齐错乱）。
 
         Returns:
             List[FrameDetections]：与 frames 一一对应

--- a/app/services/inference/detection/detector.py
+++ b/app/services/inference/detection/detector.py
@@ -149,7 +149,7 @@ class YOLODetector(Detector):
 
         return FrameDetections(
             detections=detections,
-            metadata={"model": "yolo", "frame_shape": frame.shape},
+            metadata={"model": "yolo"},  # 帧分辨率上移 FrameInference.wh，不再逐检测器塞
             timestamp=timestamp,
         )
 

--- a/app/services/inference/detection/detector.py
+++ b/app/services/inference/detection/detector.py
@@ -149,7 +149,7 @@ class YOLODetector(Detector):
 
         return FrameDetections(
             detections=detections,
-            metadata={"model": "yolo"},  # 帧分辨率上移 FrameInference.wh，不再逐检测器塞
+            metadata={"model": "yolo"},  # 帧分辨率上移 FrameInference.frame_width/height，不再逐检测器塞
             timestamp=timestamp,
         )
 

--- a/app/services/inference/detection/dispatcher.py
+++ b/app/services/inference/detection/dispatcher.py
@@ -13,7 +13,7 @@ import threading
 from collections import defaultdict, deque
 from typing import Deque, Dict, List, Optional
 
-from app.services.client import ClientManager, ClientQueues, client_manager
+from app.services.client import ClientManager, client_manager
 from app.services.inference.models import DetectionTask
 from app.utils.metrics import frame_drop_total
 from app.utils.worker_guard import guarded_run

--- a/app/services/inference/detection/pool.py
+++ b/app/services/inference/detection/pool.py
@@ -125,6 +125,9 @@ class MultiModelWorkerPool:
                 timestamp=req.timestamp,
                 detections=per_frame_results,
                 cq=req.cq,  # 透传捕获句柄，写回凭它投递
+                # 帧分辨率从原始帧盖章：fan-out 前的每帧常量，帧此后即销毁（frame.shape = H, W, C）
+                frame_width=int(req.frame.shape[1]),
+                frame_height=int(req.frame.shape[0]),
             )
             results.append(result)
 

--- a/app/services/inference/detection/service.py
+++ b/app/services/inference/detection/service.py
@@ -272,7 +272,10 @@ class ModelWorkerService:
                     )
             # 物化一次帧级 FrameFeature（多流已在 res.detections 内对齐）：帧窗 + 原子快照共用一份。
             # by_source 直接共享 res.detections 引用（pool 每帧新建、无别名突变），不复制。
-            feature = FrameFeature(ts=res.timestamp, by_source=res.detections)
+            feature = FrameFeature(
+                ts=res.timestamp, by_source=res.detections,
+                frame_width=res.frame_width, frame_height=res.frame_height,
+            )
             # Path 1: 帧窗（temporal 需要历史窗口）——一帧一条 push。
             cq.push_detection(feature)
             # Path 2: 原子快照（visualization 只需最新，保证所有 task 同帧一致；无 cq，不成自引用环）

--- a/app/services/inference/detection/service.py
+++ b/app/services/inference/detection/service.py
@@ -14,6 +14,7 @@ import threading
 import time
 from typing import Any, Dict, List, Optional
 
+from app.domain.detection import FrameFeature
 from app.services.client import ClientManager, client_manager
 from app.services.inference.detection.dispatcher import StageAwareDispatcher
 from app.services.inference.models import FrameInference
@@ -260,19 +261,22 @@ class ModelWorkerService:
                 )
                 continue
 
-            # Path 1: per-task slide_window（temporal 需要历史窗口）
+            # 失败可见性：pool 把模型异常降级成 success=False 的空结果，下游与「真没检到」
+            # 不可分。此处 res.task_id 已是确定单值（句柄按帧拆开），按 run 记一条 warning，
+            # 聚合计数由 pool.infer_failure_total 承接、此处不再重复计数。
             for task_name, detection_output in res.detections.items():
-                # 失败可见性：pool 把模型异常降级成 success=False 的空结果，下游与「真没检到」
-                # 不可分。此处 res.task_id 已是确定单值（句柄按帧拆开），按 run 记一条 warning，
-                # 聚合计数由 pool.infer_failure_total 承接、此处不再重复计数。
                 if not detection_output.success:
                     logger.warning(
                         "[Worker] inference degraded (empty result): task=%s model=%s error=%s",
                         res.task_id, task_name, detection_output.error,
                     )
-                cq.push_detection(task_name, detection_output)
-            # Path 2: 原子快照（visualization 只需最新，保证所有 task 同帧一致）
-            cq.set_latest_inference(res)
+            # 物化一次帧级 FrameFeature（多流已在 res.detections 内对齐）：帧窗 + 原子快照共用一份。
+            # by_source 直接共享 res.detections 引用（pool 每帧新建、无别名突变），不复制。
+            feature = FrameFeature(ts=res.timestamp, by_source=res.detections)
+            # Path 1: 帧窗（temporal 需要历史窗口）——一帧一条 push。
+            cq.push_detection(feature)
+            # Path 2: 原子快照（visualization 只需最新，保证所有 task 同帧一致；无 cq，不成自引用环）
+            cq.set_latest_inference(feature)
             # L2 特征落盘（常开）：offline 链路硬需求，best-effort 不影响主链路。
             # 目录键 (task_id, step_id) 与 HLS 同款；任一为 None 则跳过（拒落，同 HLS 口径）。
             # 从同一句柄派生 task_id/step_id（消除跨 snapshot 二次读的键错配窗口）。

--- a/app/services/inference/detection/service.py
+++ b/app/services/inference/detection/service.py
@@ -282,9 +282,10 @@ class ModelWorkerService:
             # 从同一句柄派生 task_id/step_id（消除跨 snapshot 二次读的键错配窗口）。
             # owner=cq：feature_store 无状态门，靠 store 内归属校验挡「顶层 is_active()
             # 通过后中途 supersede」的迟到写（分区键跨 run 共享，比 is_active() 更本质）。
+            # 落盘同一份帧级 FrameFeature（与帧窗/快照共用），append/load 两端货币一致。
             if self._feature_store is not None:
                 task_id = cq.task_id
                 step_id = cq.step_id
                 if task_id is not None and step_id is not None:
-                    self._feature_store.append(task_id, step_id, res, owner=cq)
+                    self._feature_store.append(task_id, step_id, feature, owner=cq)
 

--- a/app/services/inference/feature/store.py
+++ b/app/services/inference/feature/store.py
@@ -13,7 +13,8 @@ L2 特征聚合层「隐式」落盘点 —— 实时与离线链路都消费特
 帧对齐契约：每条记录的 `ts` = 该帧的 `FrameFeature.ts`（= 帧捕获 ts，与在线滑窗同源），
 与 HLS keypoints/段落盘所用的 `fd.timestamp` 同源同值，故 feature 行可按 `ts` 精确对上
 同帧的 HLS 证据片段与 keypoints。`append`/`load` 两端货币均为帧级 `FrameFeature`
-（`ts + {source: FrameDetections}`），落盘/回读逐值同型（离线与在线共用一套货币）。
+（`ts + {source: FrameDetections}`，离线与在线共用一套货币）；磁盘 record 是它的**精简投影**
+（只落离线必要信息，mask/keypoints/metadata 不落），对称映射见 `_feature_to_record`/`_record_to_feature`。
 """
 
 from __future__ import annotations
@@ -25,31 +26,16 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-import numpy as np
-
 from app.domain.detection import Detection, FrameDetections, FrameFeature
 from app.services.inference.models import EventFact, SegmentFact, fact_from_json
 
 logger = logging.getLogger(__name__)
 
 
-def _json_safe(obj: Any) -> Any:
-    """把 numpy 标量 / 数组转成 JSON 可序列化的原生类型。"""
-    if isinstance(obj, (np.integer,)):
-        return int(obj)
-    if isinstance(obj, (np.floating,)):
-        return float(obj)
-    if isinstance(obj, np.ndarray):
-        return obj.tolist()
-    if isinstance(obj, (list, tuple)):
-        return [_json_safe(x) for x in obj]
-    return obj
-
-
 def _serialize_detection(det) -> Dict[str, Any]:
     """单个 Detection → 特征 dict（bbox 即特征；mask/keypoints 太重不落）。"""
     return {
-        "bbox": _json_safe(det.bbox),
+        "bbox": [int(x) for x in det.bbox],  # 强制原生 int（json 不吃 np.int64），与下方 conf/cls_id 同风格
         "conf": float(det.confidence),
         "cls_id": int(det.class_id),
         "cls": det.class_name,
@@ -63,6 +49,57 @@ def _deserialize_detection(d: Dict[str, Any]) -> Detection:
         confidence=d["conf"],
         class_id=d["cls_id"],
         class_name=d["cls"],
+    )
+
+
+# ── FrameFeature ↔ 磁盘 record 的对称映射（store 私有格式，一对逆运算紧挨放置）──────────
+#
+# 契约：append/load 两端货币都是 FrameFeature；磁盘 record 是它的**精简投影**，只保留离线
+# 必要信息 = ts + 每源检测框(bbox/conf/cls) + 帧分辨率。刻意不落（回读按默认还原）：
+#   - mask/keypoints：重（seg/pose 才有，每帧一张数组），且离线不消费；
+#   - metadata / success / error：离线不消费。
+# 磁盘键全命名（frame_width/frame_height），无位置约定；位置约定只活在 Detection 的
+# bbox=[x1,y1,x2,y2]（其本身就是坐标序）。
+
+
+def _feature_to_record(feature: FrameFeature) -> Dict[str, Any]:
+    """FrameFeature → 磁盘 record（逆运算 _record_to_feature）。"""
+    record: Dict[str, Any] = {
+        "ts": feature.ts,
+        "features": {
+            source: [_serialize_detection(d) for d in fd.detections]
+            for source, fd in feature.by_source.items()
+        },
+    }
+    if feature.frame_width is not None and feature.frame_height is not None:
+        record["frame_width"] = feature.frame_width
+        record["frame_height"] = feature.frame_height
+    return record
+
+
+def _record_to_feature(rec: Dict[str, Any]) -> FrameFeature:
+    """磁盘 record → FrameFeature（_feature_to_record 的逆；未落字段按契约默认还原）。
+
+    每源 `FrameDetections.timestamp = 记录级 ts`（同帧多流同源同值）；`metadata={}`、
+    `success=True`、`mask/keypoints=None` 均为默认。含 detections 为空的 source。
+    """
+    ts = rec.get("ts", 0.0)
+    features = rec.get("features") or {}
+    by_source = {
+        source: FrameDetections(
+            detections=[_deserialize_detection(d) for d in dets],
+            metadata={},
+            timestamp=ts,
+        )
+        for source, dets in features.items()
+    }
+    fw = rec.get("frame_width")
+    fh = rec.get("frame_height")
+    return FrameFeature(
+        ts=ts,
+        by_source=by_source,
+        frame_width=int(fw) if fw is not None else None,
+        frame_height=int(fh) if fh is not None else None,
     )
 
 
@@ -202,17 +239,7 @@ class FeatureStore(_JsonlBuffer):
         if task_id is None or step_id is None:
             return
         try:
-            features = {
-                source: [_serialize_detection(d) for d in fd.detections]
-                for source, fd in feature.by_source.items()
-            }
-            # ts = 帧捕获 ts（feature.ts），供离线/证据按帧对齐，详见模块 docstring
-            record = {"ts": feature.ts, "features": features}
-            # 磁盘沿用紧凑数组 wh = [width, height]（帧级，pool 盖章）：读写各一处、就地注释；
-            # 内存契约用显式 frame_width/frame_height，不外泄位置约定。无分辨率则省略该键。
-            if feature.frame_width is not None and feature.frame_height is not None:
-                record["wh"] = [feature.frame_width, feature.frame_height]
-            line = json.dumps(record, ensure_ascii=False) + "\n"
+            line = json.dumps(_feature_to_record(feature), ensure_ascii=False) + "\n"
         except Exception as e:  # 序列化失败 best-effort 跳过
             logger.warning("[FeatureStore] 特征序列化失败 task=%s step=%s: %s", task_id, step_id, e)
             return
@@ -221,12 +248,10 @@ class FeatureStore(_JsonlBuffer):
     def load(self, task_id: Any, step_id: Any) -> List[FrameFeature]:
         """离线回读：把整段特征还原为帧级 `FrameFeature` 序列（与在线滑窗同型）。
 
-        先 flush 缓冲，再**单次顺序扫 features.jsonl**，每行还原成一个
-        `FrameFeature(ts, by_source={source: FrameDetections})`——含该行 features 里的全部 source
-        （含 detections 为空的 source，present-key 天然落在 by_source 键集上）。返回按 `ts` 升序。
-        文件缺失返回 `[]`；单行损坏记 warning 后跳过、不中断其余数据。
-        注：mask/keypoints 未落盘，回读为 None；FrameDetections.metadata 不落盘、回读为空。
-        记录含 `wh`（磁盘紧凑数组 [w,h]）时还原到帧级 `FrameFeature.frame_width/height`，供离线空间归一化。
+        先 flush 缓冲，再**单次顺序扫 features.jsonl**，每行经 `_record_to_feature` 还原成一个
+        `FrameFeature`（含该行 features 里的全部 source，含 detections 为空的 source，present-key
+        天然落在 by_source 键集上）。返回按 `ts` 升序。文件缺失返回 `[]`；单行损坏记 warning 后跳过、
+        不中断其余数据。未落字段（mask/keypoints/metadata/success）按契约默认还原，详见 `_record_to_feature`。
 
         Args:
             task_id: 任务 id
@@ -249,23 +274,7 @@ class FeatureStore(_JsonlBuffer):
                     except Exception as e:  # 单行损坏：跳过不中断其余数据
                         logger.warning("[FeatureStore] 跳过损坏行 %s: %s", path, e)
                         continue
-                    features = rec.get("features") or {}
-                    ts = rec.get("ts", 0.0)
-                    # 帧分辨率随记录落盘（帧级 wh 数组）；回读还原到 FrameFeature.frame_width/height，供离线空间归一化
-                    # 按真实尺寸换算。老记录无 wh 时留 None，segmenter 走默认兜底。
-                    wh = rec.get("wh")  # 磁盘紧凑数组 [width, height]
-                    fw = fh = None
-                    if isinstance(wh, (list, tuple)) and len(wh) >= 2:
-                        fw, fh = int(wh[0]), int(wh[1])
-                    by_source = {
-                        source: FrameDetections(
-                            detections=[_deserialize_detection(d) for d in dets],
-                            metadata={},
-                            timestamp=ts,
-                        )
-                        for source, dets in features.items()
-                    }
-                    frames.append(FrameFeature(ts=ts, by_source=by_source, frame_width=fw, frame_height=fh))
+                    frames.append(_record_to_feature(rec))
         except Exception as e:
             logger.warning("[FeatureStore] 回读失败 %s: %s", path, e)
         frames.sort(key=lambda ff: ff.ts)

--- a/app/services/inference/feature/store.py
+++ b/app/services/inference/feature/store.py
@@ -83,7 +83,7 @@ def _record_to_feature(rec: Dict[str, Any]) -> FrameFeature:
     每源 `FrameDetections.timestamp = 记录级 ts`（同帧多流同源同值）；`metadata={}`、
     `success=True`、`mask/keypoints=None` 均为默认。含 detections 为空的 source。
     """
-    ts = rec.get("ts", 0.0)
+    ts = float(rec.get("ts", 0.0))  # 反序列化边界统一 float（手写 JSONL 可能给 int）
     features = rec.get("features") or {}
     by_source = {
         source: FrameDetections(

--- a/app/services/inference/feature/store.py
+++ b/app/services/inference/feature/store.py
@@ -23,7 +23,7 @@ import logging
 import os
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -64,23 +64,6 @@ def _deserialize_detection(d: Dict[str, Any]) -> Detection:
         class_id=d["cls_id"],
         class_name=d["cls"],
     )
-
-
-def _extract_frame_wh(detections_by_task: Dict[str, Any]) -> Optional[Tuple[int, int]]:
-    """从任一检测器帧的 metadata.frame_shape (H, W, C) 提取 (width, height)。
-
-    离线空间归一化（bbox → cx/cy/area）需按真实分辨率换算；但特征回读时 metadata
-    整个被丢，segmenter 只能退回硬编码默认。这里把帧分辨率随记录落盘，让离线可恢复。
-    同一帧所有检测器看同一分辨率，取首个可用值即可；无任何 frame_shape 时返回 None，
-    离线仍按默认兜底（老 features.jsonl 无该字段时同样优雅降级）。
-    """
-    for out in detections_by_task.values():
-        shape = (getattr(out, "metadata", None) or {}).get("frame_shape")
-        if shape is not None and len(shape) >= 2:
-            height, width = int(shape[0]), int(shape[1])
-            if width > 0 and height > 0:
-                return width, height
-    return None
 
 
 class _JsonlBuffer:
@@ -225,10 +208,10 @@ class FeatureStore(_JsonlBuffer):
             }
             # ts = 帧捕获 ts（feature.ts），供离线/证据按帧对齐，详见模块 docstring
             record = {"ts": feature.ts, "features": features}
-            # wh = 帧分辨率 [width, height]，供离线空间归一化恢复真实尺寸（无则省略）
-            wh = _extract_frame_wh(feature.by_source)
-            if wh is not None:
-                record["wh"] = list(wh)
+            # 磁盘沿用紧凑数组 wh = [width, height]（帧级，pool 盖章）：读写各一处、就地注释；
+            # 内存契约用显式 frame_width/frame_height，不外泄位置约定。无分辨率则省略该键。
+            if feature.frame_width is not None and feature.frame_height is not None:
+                record["wh"] = [feature.frame_width, feature.frame_height]
             line = json.dumps(record, ensure_ascii=False) + "\n"
         except Exception as e:  # 序列化失败 best-effort 跳过
             logger.warning("[FeatureStore] 特征序列化失败 task=%s step=%s: %s", task_id, step_id, e)
@@ -242,8 +225,8 @@ class FeatureStore(_JsonlBuffer):
         `FrameFeature(ts, by_source={source: FrameDetections})`——含该行 features 里的全部 source
         （含 detections 为空的 source，present-key 天然落在 by_source 键集上）。返回按 `ts` 升序。
         文件缺失返回 `[]`；单行损坏记 warning 后跳过、不中断其余数据。
-        注：mask/keypoints 未落盘，回读为 None；每个 FrameDetections.metadata 仅在记录含 `wh`
-        （帧分辨率）时回填 `frame_width`/`frame_height`，供离线空间归一化恢复真实尺寸，其余键不落盘。
+        注：mask/keypoints 未落盘，回读为 None；FrameDetections.metadata 不落盘、回读为空。
+        记录含 `wh`（磁盘紧凑数组 [w,h]）时还原到帧级 `FrameFeature.frame_width/height`，供离线空间归一化。
 
         Args:
             task_id: 任务 id
@@ -268,21 +251,21 @@ class FeatureStore(_JsonlBuffer):
                         continue
                     features = rec.get("features") or {}
                     ts = rec.get("ts", 0.0)
-                    # 帧分辨率随记录落盘（写入端 _extract_frame_wh）；回读还原到 metadata
-                    # 供离线空间归一化按真实尺寸换算。老记录无 wh 时留空，segmenter 走默认兜底。
-                    wh = rec.get("wh")
-                    frame_meta: Dict[str, Any] = {}
+                    # 帧分辨率随记录落盘（帧级 wh 数组）；回读还原到 FrameFeature.frame_width/height，供离线空间归一化
+                    # 按真实尺寸换算。老记录无 wh 时留 None，segmenter 走默认兜底。
+                    wh = rec.get("wh")  # 磁盘紧凑数组 [width, height]
+                    fw = fh = None
                     if isinstance(wh, (list, tuple)) and len(wh) >= 2:
-                        frame_meta = {"frame_width": wh[0], "frame_height": wh[1]}
+                        fw, fh = int(wh[0]), int(wh[1])
                     by_source = {
                         source: FrameDetections(
                             detections=[_deserialize_detection(d) for d in dets],
-                            metadata=dict(frame_meta),
+                            metadata={},
                             timestamp=ts,
                         )
                         for source, dets in features.items()
                     }
-                    frames.append(FrameFeature(ts=ts, by_source=by_source))
+                    frames.append(FrameFeature(ts=ts, by_source=by_source, frame_width=fw, frame_height=fh))
         except Exception as e:
             logger.warning("[FeatureStore] 回读失败 %s: %s", path, e)
         frames.sort(key=lambda ff: ff.ts)

--- a/app/services/inference/feature/store.py
+++ b/app/services/inference/feature/store.py
@@ -10,9 +10,10 @@ L2 特征聚合层「隐式」落盘点 —— 实时与离线链路都消费特
 见 `hls_strategy._persist_*_segment`），随 step 目录被 cleanup TTL 连带回收。
 两者均为 manager 持有的单例：构造时绑定 base_dir，stop_workflow 时 close(task_id, step_id)。
 
-帧对齐契约：每条记录的 `ts` = 该帧的 `FrameInference.timestamp`（= 帧捕获 ts，见
-`workers/base.py` 构造），与 HLS keypoints/段落盘所用的 `fd.timestamp` 同源同值，
-故 feature 行可按 `ts` 精确对上同帧的 HLS 证据片段与 keypoints。
+帧对齐契约：每条记录的 `ts` = 该帧的 `FrameFeature.ts`（= 帧捕获 ts，与在线滑窗同源），
+与 HLS keypoints/段落盘所用的 `fd.timestamp` 同源同值，故 feature 行可按 `ts` 精确对上
+同帧的 HLS 证据片段与 keypoints。`append`/`load` 两端货币均为帧级 `FrameFeature`
+（`ts + {source: FrameDetections}`），落盘/回读逐值同型（离线与在线共用一套货币）。
 """
 
 from __future__ import annotations
@@ -22,11 +23,11 @@ import logging
 import os
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from app.domain.detection import Detection, FrameDetections
+from app.domain.detection import Detection, FrameDetections, FrameFeature
 from app.services.inference.models import EventFact, SegmentFact, fact_from_json
 
 logger = logging.getLogger(__name__)
@@ -206,26 +207,26 @@ class FeatureStore(_JsonlBuffer):
     def __init__(self, base_dir: Union[str, Path], batch_size: int = 64):
         super().__init__(base_dir, suffix="features", batch_size=batch_size)
 
-    def append(self, task_id: Any, step_id: Any, res, owner: Any = None) -> None:
-        """追加一帧的多模型特征。
+    def append(self, task_id: Any, step_id: Any, feature: "FrameFeature", owner: Any = None) -> None:
+        """追加一帧的多流特征（帧级 FrameFeature）。
 
         Args:
             task_id: 任务 id（落盘目录键）
             step_id: 洗消步骤 id（落盘目录键，与 HLS 同款 `{task_id}/{step_id}/`）
-            res: FrameInference（duck-typed：.timestamp + .result[task_name]→FrameDetections）
+            feature: FrameFeature（.ts + .by_source[流名]→FrameDetections，与在线滑窗同源同型）
             owner: 本次写属的 run（= cq 对象）；与分区当前 owner 不符即被拒（迟到于 supersede）
         """
         if task_id is None or step_id is None:
             return
         try:
             features = {
-                task_name: [_serialize_detection(d) for d in out.detections]
-                for task_name, out in res.detections.items()
+                source: [_serialize_detection(d) for d in fd.detections]
+                for source, fd in feature.by_source.items()
             }
-            # ts = 帧捕获 ts（res.timestamp），供离线/证据按帧对齐，详见模块 docstring
-            record = {"ts": res.timestamp, "features": features}
+            # ts = 帧捕获 ts（feature.ts），供离线/证据按帧对齐，详见模块 docstring
+            record = {"ts": feature.ts, "features": features}
             # wh = 帧分辨率 [width, height]，供离线空间归一化恢复真实尺寸（无则省略）
-            wh = _extract_frame_wh(res.detections)
+            wh = _extract_frame_wh(feature.by_source)
             if wh is not None:
                 record["wh"] = list(wh)
             line = json.dumps(record, ensure_ascii=False) + "\n"
@@ -234,40 +235,25 @@ class FeatureStore(_JsonlBuffer):
             return
         self._enqueue(task_id, step_id, [line], owner=owner)
 
-    def load(self, task_id: Any, step_id: Any, source: str) -> List[FrameDetections]:
-        """离线回读：把某 source（检测点/模型名）的全序列特征还原为 FrameDetections 列表。
+    def load(self, task_id: Any, step_id: Any) -> List[FrameFeature]:
+        """离线回读：把整段特征还原为帧级 `FrameFeature` 序列（与在线滑窗同型）。
 
-        供离线链路使用（offline 预置）。委托 `load_many` 的单 source 版本，语义不变。
-
-        Args:
-            task_id: 任务 id
-            step_id: 洗消步骤 id
-            source: 检测点名（= Detector/Analyzer.name），对应每帧 features[source]
-        """
-        return self.load_many(task_id, step_id, [source]).get(source, [])
-
-    def load_many(
-        self, task_id: Any, step_id: Any, sources: Sequence[str]
-    ) -> Dict[str, List[FrameDetections]]:
-        """离线回读：一次扫描把多个 source 的全序列特征各自还原为 FrameDetections 列表。
-
-        供离线链路使用（offline 预置）。先 flush 缓冲，再**单次顺序扫 features.jsonl**
-        （不为每个 source 重复读整文件）。每个 source 保留所有含该 key 的帧（含 detections 为空
-        的帧），返回序列按 `ts` 升序。文件缺失时每个 source 返回空列表；单行损坏记 warning 后
-        跳过、不中断其余数据。
-        注：mask/keypoints 未落盘，回读为 None；metadata 仅在记录含 `wh`（帧分辨率）时
-        回填 `frame_width`/`frame_height`，供离线空间归一化恢复真实尺寸，其余键不落盘。
+        先 flush 缓冲，再**单次顺序扫 features.jsonl**，每行还原成一个
+        `FrameFeature(ts, by_source={source: FrameDetections})`——含该行 features 里的全部 source
+        （含 detections 为空的 source，present-key 天然落在 by_source 键集上）。返回按 `ts` 升序。
+        文件缺失返回 `[]`；单行损坏记 warning 后跳过、不中断其余数据。
+        注：mask/keypoints 未落盘，回读为 None；每个 FrameDetections.metadata 仅在记录含 `wh`
+        （帧分辨率）时回填 `frame_width`/`frame_height`，供离线空间归一化恢复真实尺寸，其余键不落盘。
 
         Args:
             task_id: 任务 id
             step_id: 洗消步骤 id
-            sources: 检测点名列表（= Detector.name），各对应每帧 features[source]
         """
-        outputs: Dict[str, List[FrameDetections]] = {src: [] for src in sources}
+        frames: List[FrameFeature] = []
         self.flush(task_id, step_id)
         path = self._path(task_id, step_id)
         if not path.exists():
-            return outputs
+            return frames
         try:
             # utf-8-sig 容忍 Windows 手写 features.jsonl 的 UTF-8 BOM；后端自身写出的无 BOM 亦正常。
             with path.open("r", encoding="utf-8-sig") as f:
@@ -288,20 +274,19 @@ class FeatureStore(_JsonlBuffer):
                     frame_meta: Dict[str, Any] = {}
                     if isinstance(wh, (list, tuple)) and len(wh) >= 2:
                         frame_meta = {"frame_width": wh[0], "frame_height": wh[1]}
-                    for src in sources:
-                        dets = features.get(src)
-                        if dets is None:
-                            continue
-                        outputs[src].append(FrameDetections(
+                    by_source = {
+                        source: FrameDetections(
                             detections=[_deserialize_detection(d) for d in dets],
                             metadata=dict(frame_meta),
                             timestamp=ts,
-                        ))
+                        )
+                        for source, dets in features.items()
+                    }
+                    frames.append(FrameFeature(ts=ts, by_source=by_source))
         except Exception as e:
             logger.warning("[FeatureStore] 回读失败 %s: %s", path, e)
-        for src in sources:
-            outputs[src].sort(key=lambda fd: fd.timestamp)
-        return outputs
+        frames.sort(key=lambda ff: ff.ts)
+        return frames
 
 
 class FactLedger(_JsonlBuffer):

--- a/app/services/inference/manager.py
+++ b/app/services/inference/manager.py
@@ -15,7 +15,7 @@ VisualizationWorker (~15Hz) → cq.get_latest_inference() + get_latest_frame() +
 import logging
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional
 
 from app.domain.alarm import ALARM_MODE_SETTLEMENT, Alarm
 from app.services.client import ClientQueues, client_manager

--- a/app/services/inference/models.py
+++ b/app/services/inference/models.py
@@ -48,10 +48,10 @@ class DetectionTask:
 class FrameInference:
     """推理结果：一帧多检测器聚合（detections[detector_name] = FrameDetections）。
 
-    timestamp 为帧捕获 ts，供 VisualizationWorker 按帧去重（同帧只渲染一次）。
+    timestamp 为帧捕获 ts。本对象是 pool→写回口的传输消息，不被 cq 留存（写回口把
+    detections 物化成 FrameFeature 存入 slide_window/latest_inference，二者均无 cq）。
     cq 为从对应 DetectionTask 透传的捕获句柄，写回只写它、不反查；旧句柄经 CQ 状态机
-    （DRAINING/CLOSED）被挡，碰不到新 run。注：set_latest_inference 把本对象存进 cq 后形成
-    cq→_latest_inference→cq 自引用环，benign（GC 处理循环，close() 释放 payload 时断开）。
+    （DRAINING/CLOSED）被挡，碰不到新 run。
     """
 
     task_id: int

--- a/app/services/inference/models.py
+++ b/app/services/inference/models.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -52,6 +52,8 @@ class FrameInference:
     detections 物化成 FrameFeature 存入 slide_window/latest_inference，二者均无 cq）。
     cq 为从对应 DetectionTask 透传的捕获句柄，写回只写它、不反查；旧句柄经 CQ 状态机
     （DRAINING/CLOSED）被挡，碰不到新 run。
+    frame_width/frame_height 为帧分辨率：fan-out 前定死的每帧常量，pool 从原始帧盖章、随本消息透传，
+    写回口物化进 FrameFeature（原始帧此后即销毁，此处是唯一采集时机）。拆两字段避免 (w,h) 隐式序混淆。
     """
 
     task_id: int
@@ -59,6 +61,8 @@ class FrameInference:
     timestamp: float
     detections: Dict[str, FrameDetections]
     cq: "ClientQueues"
+    frame_width: Optional[int] = None
+    frame_height: Optional[int] = None
 
 
 # ==================== 离线预留事实契约（L3 时序分析层产出）====================

--- a/app/services/inference/offline/runner.py
+++ b/app/services/inference/offline/runner.py
@@ -79,17 +79,16 @@ class OfflineRunner:
             return OfflineRunResult("skipped", None, 0, f"stage '{stage_key}' offline 未启用")
 
         producer = segmenter.name
-        streams = self._feature_store.load_many(
-            spec.task_id, spec.step_id, segmenter.subscribes
-        )
-        empty = [s for s in segmenter.subscribes if not streams.get(s)]
+        frames = self._feature_store.load(spec.task_id, spec.step_id)
+        present = set().union(*(ff.by_source.keys() for ff in frames)) if frames else set()
+        empty = [s for s in segmenter.subscribes if s not in present]
         if empty:
             # 任一订阅 source 无数据：跳过，不覆盖旧事实
             return OfflineRunResult(
                 "skipped", producer, 0, f"订阅 source 无特征: {empty}"
             )
 
-        model_input = segmenter.preprocess(streams)
+        model_input = segmenter.preprocess(frames)
         facts = segmenter.segment(model_input)  # 算法异常向上抛出，不写
 
         validated = self._validate_and_stamp(facts, producer)

--- a/app/services/inference/offline/segmenter.py
+++ b/app/services/inference/offline/segmenter.py
@@ -5,28 +5,29 @@
 （segmenter/runner/cli）不掺实现。
 
 管线两段：
-    load_many(subscribes) → raw FrameDetections 序列（按 source 分组、按 ts 升序）
+    load(task_id, step_id) → List[FrameFeature]（帧级、多流已对齐、按 ts 升序）
         │
-        ▼ preprocess(streams)   ← 输入预处理层（预留）：raw bbox 序列不一定能直接喂模型，
+        ▼ preprocess(frames)    ← 输入预处理层（预留）：raw bbox 序列不一定能直接喂模型，
         │                          需张量化/归一化/时间降采样/定长编码的模型在此转换
         ▼ segment(model_input)  ← 模型推理 + 解码为 SegmentFact
         │
         ▼ List[SegmentFact]
 
 约束：
-- `streams` 只读，不得原地修改；
+- `frames` 只读，不得原地修改；
 - 策略不访问 FeatureStore / FactLedger / ClientManager / CQ / 数据库（纯算法）；
 - 输出每条 `SegmentFact.source` 必须等于本策略 `name`；`start <= end`、时间为有限数、`0 <= conf <= 1`
   （由 Runner 统一校验，见 runner.py）。
-- 输入吃 `FrameDetections`（domain）、输出吐 `SegmentFact`（inference.models），不自定义中间数据壳。
+- 输入吃 `FrameFeature`（domain，与在线滑窗同型）、输出吐 `SegmentFact`（inference.models），
+  不自定义中间数据壳。
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Mapping, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameFeature
 from app.services.inference.models import SegmentFact
 
 
@@ -42,13 +43,12 @@ class OfflineSegmenter(ABC):
         self.subscribes: List[str] = list(subscribes)
 
     @abstractmethod
-    def preprocess(
-        self, streams: Mapping[str, Sequence[FrameDetections]]
-    ) -> Any:
-        """输入预处理接口：把 raw FrameDetections 序列转成模型可消费的输入。
+    def preprocess(self, frames: Sequence[FrameFeature]) -> Any:
+        """输入预处理接口：把帧级 FrameFeature 序列转成模型可消费的输入。
 
         基类只约束调用形状，不做默认特征工程。bbox 归一化、top-k 目标选择、
         speed 的 dt 计算、tensor 化、权重加载等都应由具体策略在自己的单文件里完成。
+        `frames` 已按 ts 升序、多流在各 `FrameFeature.by_source` 内对齐（load 保证）。
         """
         raise NotImplementedError
 

--- a/app/services/inference/offline/segmenters/clean.py
+++ b/app/services/inference/offline/segmenters/clean.py
@@ -207,10 +207,9 @@ def _effective_fps(timestamps: Sequence[float], fallback_fps: float) -> float:
 
 
 def _frame_size(frame: FrameFeature, frame_width: int, frame_height: int) -> Tuple[int, int]:
-    """优先取帧任一流 metadata 里的宽高（同帧各流同值），缺失时回退传入的默认尺寸。"""
-    meta = next((fd.metadata for fd in frame.by_source.values() if fd.metadata), {})
-    width = meta.get("frame_width") or meta.get("width") or frame_width
-    height = meta.get("frame_height") or meta.get("height") or frame_height
+    """优先取帧级 `FrameFeature.frame_width/height`（pool 盖章、store 回读还原），缺失时回退传入默认。"""
+    width = frame.frame_width or frame_width
+    height = frame.frame_height or frame_height
     return max(1, int(width)), max(1, int(height))
 
 

--- a/app/services/inference/offline/segmenters/clean.py
+++ b/app/services/inference/offline/segmenters/clean.py
@@ -6,8 +6,8 @@
     - 模型输出到 SegmentFact 的解码逻辑。
 
 输入:
-    OfflineRunner 从 FeatureStore.load_many(task_id, step_id, subscribes)
-    读取 Mapping[source, Sequence[FrameDetections]]。
+    OfflineRunner 从 FeatureStore.load(task_id, step_id) 读取 List[FrameFeature]
+    （帧级、多流已在 by_source 内对齐、按 ts 升序）。
 
 输出:
     List[SegmentFact]，由 Runner 校验并幂等写入 FactLedger。
@@ -23,11 +23,11 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 import numpy as np
 
-from app.domain.detection import Detection, FrameDetections
+from app.domain.detection import Detection, FrameFeature
 from app.services.inference.models import SegmentFact
 from app.services.inference.offline.segmenter import OfflineSegmenter
 
@@ -126,15 +126,18 @@ class ModelInput:
 
 
 def build_base_features(
-    frames: Sequence[FrameDetections],
+    frames: Sequence[FrameFeature],
     fps: float,
     frame_width: int = 640,
     frame_height: int = 480,
 ) -> ModelInput:
-    """把 clean 检测框序列转换成 v2 固定维（113）时序特征。"""
+    """把 clean 帧级 FrameFeature 序列转换成 v2 固定维（113）时序特征。
+
+    每帧 `FrameFeature.by_source` 里的多流检测在此按帧合并消费（无需上游先融合）。
+    """
     frame_width = max(1, int(frame_width))
     frame_height = max(1, int(frame_height))
-    timestamps = [float(f.timestamp) for f in frames]
+    timestamps = [float(ff.ts) for ff in frames]
     frame_count = len(frames)
     if frame_count <= 0:
         return ModelInput(features=[], feature_names=base_feature_names(), timestamps=[], fps=float(fps))
@@ -162,27 +165,31 @@ def _finite_matrix(values: np.ndarray) -> np.ndarray:
 
 
 def _collect_object_arrays(
-    frames: Sequence[FrameDetections], frame_width: int, frame_height: int
+    frames: Sequence[FrameFeature], frame_width: int, frame_height: int
 ) -> Dict[str, List[np.ndarray]]:
-    """把每帧检测框按目标类别归拢成 {obj: [每检测框一个 [T,5] 稀疏数组]}。"""
+    """把每帧检测框按目标类别归拢成 {obj: [每检测框一个 [T,5] 稀疏数组]}。
+
+    每帧遍历 `FrameFeature.by_source` 各流的检测（多流按帧合并，同 idx 落同一行）。
+    """
     frame_count = len(frames)
     out: Dict[str, List[np.ndarray]] = {name: [] for name in OBJECTS}
-    for idx, frame in enumerate(frames):
-        width, height = _frame_size(frame, frame_width, frame_height)
-        for det in frame.detections:
-            obj = OBJECT_ALIASES.get(str(det.class_name))
-            if obj is None:
-                continue
-            cx, cy, area = _bbox_to_center_area(det, width, height)
-            arr = np.zeros((frame_count, 5), dtype=np.float32)
-            arr[idx] = (
-                1.0,
-                float(cx),
-                float(cy),
-                float(area),
-                max(0.0, min(1.0, float(det.confidence))),
-            )
-            out[obj].append(arr)
+    for idx, ff in enumerate(frames):
+        width, height = _frame_size(ff, frame_width, frame_height)
+        for fd in ff.by_source.values():
+            for det in fd.detections:
+                obj = OBJECT_ALIASES.get(str(det.class_name))
+                if obj is None:
+                    continue
+                cx, cy, area = _bbox_to_center_area(det, width, height)
+                arr = np.zeros((frame_count, 5), dtype=np.float32)
+                arr[idx] = (
+                    1.0,
+                    float(cx),
+                    float(cy),
+                    float(area),
+                    max(0.0, min(1.0, float(det.confidence))),
+                )
+                out[obj].append(arr)
     return out
 
 
@@ -199,9 +206,9 @@ def _effective_fps(timestamps: Sequence[float], fallback_fps: float) -> float:
     return max(1.0 / float(np.median(np.asarray(deltas, dtype=np.float32))), 1e-6)
 
 
-def _frame_size(frame: FrameDetections, frame_width: int, frame_height: int) -> Tuple[int, int]:
-    """优先取帧 metadata 里的宽高，缺失时回退传入的默认尺寸。"""
-    meta = frame.metadata or {}
+def _frame_size(frame: FrameFeature, frame_width: int, frame_height: int) -> Tuple[int, int]:
+    """优先取帧任一流 metadata 里的宽高（同帧各流同值），缺失时回退传入的默认尺寸。"""
+    meta = next((fd.metadata for fd in frame.by_source.values() if fd.metadata), {})
     width = meta.get("frame_width") or meta.get("width") or frame_width
     height = meta.get("frame_height") or meta.get("height") or frame_height
     return max(1, int(width)), max(1, int(height))
@@ -572,23 +579,14 @@ class _CleanTorchSegmenter(OfflineSegmenter):
         self._normalizer: Tuple[Any, Any] | None = None
         self._last_result: dict | None = None
 
-    def preprocess(self, streams: Mapping[str, Sequence[FrameDetections]]) -> ModelInput:
-        """跨源按时间戳融合成逐帧序列，再算基础 v2 特征并叠加模型专属 recipe。"""
-        by_ts: Dict[float, List[Detection]] = {}
-        metadata_by_ts: Dict[float, dict] = {}
-        for src in self.subscribes:
-            for fd in streams.get(src, ()):
-                ts = float(fd.timestamp)
-                by_ts.setdefault(ts, []).extend(fd.detections)
-                if fd.metadata:
-                    metadata_by_ts.setdefault(ts, {}).update(fd.metadata)
+    def preprocess(self, frames: Sequence[FrameFeature]) -> ModelInput:
+        """帧级 FrameFeature 序列 → 基础 v2 特征 + 模型专属 recipe。
 
-        frames = [
-            FrameDetections(detections=by_ts[ts], metadata=metadata_by_ts.get(ts, {}), timestamp=ts)
-            for ts in sorted(by_ts)
-        ]
-        base = build_base_features(frames, self.fps, self.frame_width, self.frame_height)
-        return self.transform_features(base)
+        多流按帧合并折进 build_base_features（`frames` 已按 ts 升序、各流在 by_source 内对齐）。
+        """
+        return self.transform_features(
+            build_base_features(frames, self.fps, self.frame_width, self.frame_height)
+        )
 
     def transform_features(self, model_input: ModelInput) -> ModelInput:
         """模型专属特征转换虚函数；子类按自身 checkpoint 的 recipe 覆盖。"""

--- a/app/services/inference/offline/segmenters/clean.py
+++ b/app/services/inference/offline/segmenters/clean.py
@@ -84,7 +84,7 @@ class ModelInput:
 
     features:
         [T, F] 数值特征矩阵。基础 v2 为 113 维；具体模型可在
-        transform_features() 内扩展为 121/249 等模型专属输入。
+        覆盖的 preprocess() 内扩展为 121/249 等模型专属输入。
     feature_names:
         features 每一列的名字，便于训练仓和后端排查对齐问题。
     timestamps:
@@ -122,7 +122,7 @@ class ModelInput:
 #     - 最后补时间位置编码。
 #
 # 这些是无状态函数（原 FeatureVectorizer 类无跨调用状态，只是命名空间）。窗口统计、
-# 业务先验等模型专属增强由各模型在 transform_features() 内自行叠加。
+# 业务先验等模型专属增强由各模型在覆盖的 preprocess() 内自行叠加。
 
 
 def build_base_features(
@@ -137,7 +137,7 @@ def build_base_features(
     """
     frame_width = max(1, int(frame_width))
     frame_height = max(1, int(frame_height))
-    timestamps = [float(ff.ts) for ff in frames]
+    timestamps = [ff.ts for ff in frames]  # FrameFeature.ts 已在 store.load 边界统一 float
     frame_count = len(frames)
     if frame_count <= 0:
         return ModelInput(features=[], feature_names=base_feature_names(), timestamps=[], fps=float(fps))
@@ -174,7 +174,9 @@ def _collect_object_arrays(
     frame_count = len(frames)
     out: Dict[str, List[np.ndarray]] = {name: [] for name in OBJECTS}
     for idx, ff in enumerate(frames):
-        width, height = _frame_size(ff, frame_width, frame_height)
+        # 帧级分辨率优先（pool 盖章、store 回读还原）；缺失回退传入默认。同帧各流同值。
+        width = max(1, int(ff.frame_width or frame_width))
+        height = max(1, int(ff.frame_height or frame_height))
         for fd in ff.by_source.values():
             for det in fd.detections:
                 obj = OBJECT_ALIASES.get(str(det.class_name))
@@ -204,13 +206,6 @@ def _effective_fps(timestamps: Sequence[float], fallback_fps: float) -> float:
     if not deltas:
         return max(float(fallback_fps), 1e-6)
     return max(1.0 / float(np.median(np.asarray(deltas, dtype=np.float32))), 1e-6)
-
-
-def _frame_size(frame: FrameFeature, frame_width: int, frame_height: int) -> Tuple[int, int]:
-    """优先取帧级 `FrameFeature.frame_width/height`（pool 盖章、store 回读还原），缺失时回退传入默认。"""
-    width = frame.frame_width or frame_width
-    height = frame.frame_height or frame_height
-    return max(1, int(width)), max(1, int(height))
 
 
 def _bbox_to_center_area(det: Detection, width: int, height: int) -> Tuple[float, float, float]:
@@ -418,7 +413,7 @@ def _build_feature_matrix(
     return _finite_matrix(np.concatenate(blocks, axis=1)), names
 
 
-# -------------------- 模型专属特征 recipe（供子类 transform_features 调用） --------------------
+# -------------------- 模型专属特征 recipe（供子类覆盖的 preprocess 调用） --------------------
 
 
 def _with_features(model_input: ModelInput, features: np.ndarray, names: List[str], version: str) -> ModelInput:
@@ -549,10 +544,9 @@ def add_business_priors(model_input: ModelInput) -> ModelInput:
 class _CleanTorchSegmenter(OfflineSegmenter):
     """clean 模型策略基类：torch 模型加载 + 推理 + SegmentFact 解码。
 
-    特征工程是模块级纯函数：preprocess 内联跨源融合后调 build_base_features 得基础 v2，
-    再经 transform_features() 叠加模型专属 recipe。transform_features() 是模型专属特征
-    接口，子类按自身 checkpoint 覆盖，调用模块级特征函数（add_business_priors /
-    add_centered_window_stats）。
+    特征工程是模块级纯函数：`preprocess` 调 build_base_features 得基础 v2（113 维）；
+    需叠加模型专属 recipe 的子类**覆盖 preprocess**，用 `super().preprocess()` 取基础特征后
+    再调模块级特征函数（add_business_priors / add_centered_window_stats）。
     """
 
     model_version = "clean_model_v1"
@@ -579,17 +573,12 @@ class _CleanTorchSegmenter(OfflineSegmenter):
         self._last_result: dict | None = None
 
     def preprocess(self, frames: Sequence[FrameFeature]) -> ModelInput:
-        """帧级 FrameFeature 序列 → 基础 v2 特征 + 模型专属 recipe。
+        """帧级 FrameFeature 序列 → 基础 v2 特征（113 维）。
 
         多流按帧合并折进 build_base_features（`frames` 已按 ts 升序、各流在 by_source 内对齐）。
+        需叠加模型专属 recipe 的子类覆盖本方法，用 `super().preprocess()` 取基础特征后再变换。
         """
-        return self.transform_features(
-            build_base_features(frames, self.fps, self.frame_width, self.frame_height)
-        )
-
-    def transform_features(self, model_input: ModelInput) -> ModelInput:
-        """模型专属特征转换虚函数；子类按自身 checkpoint 的 recipe 覆盖。"""
-        return model_input
+        return build_base_features(frames, self.fps, self.frame_width, self.frame_height)
 
     def segment(self, model_input: ModelInput) -> List[SegmentFact]:
         """跑模型得到逐帧标签，解码成 SegmentFact；未配 model_path 硬失败，不做规则降级。"""
@@ -922,8 +911,8 @@ class CleanASFormerSegmenter(_CleanTorchSegmenter):
     model_version = "clean_asformer_v1"
     feature_method = "business_priors"
 
-    def transform_features(self, model_input: ModelInput) -> ModelInput:
-        return add_business_priors(model_input)
+    def preprocess(self, frames: Sequence[FrameFeature]) -> ModelInput:
+        return add_business_priors(super().preprocess(frames))
 
     def _build_model(self, in_dim: int, class_count: int):
         return _make_asformer(in_dim, class_count)
@@ -939,8 +928,8 @@ class CleanBiGRUSegmenter(_CleanTorchSegmenter):
     model_version = "clean_bigru_v1"
     feature_method = "window_stats+business_priors"
 
-    def transform_features(self, model_input: ModelInput) -> ModelInput:
-        return add_business_priors(add_centered_window_stats(model_input))
+    def preprocess(self, frames: Sequence[FrameFeature]) -> ModelInput:
+        return add_business_priors(add_centered_window_stats(super().preprocess(frames)))
 
     def _build_model(self, in_dim: int, class_count: int):
         return _make_bigru(in_dim, class_count)

--- a/app/services/inference/offline/segmenters/mock.py
+++ b/app/services/inference/offline/segmenters/mock.py
@@ -7,19 +7,18 @@
     2. 单测/本地 smoke test 不依赖 torch、GPU、真实 clean 权重。
 
 输入:
-    preprocess(streams) 接收 FeatureStore.load_many 返回的
-    Mapping[source, Sequence[FrameDetections]]，原样传给 segment。
+    preprocess(frames) 接收 FeatureStore.load 返回的 List[FrameFeature]，原样传给 segment。
 
 输出:
-    segment(model_input) 返回 List[SegmentFact]。只要某个 ts 的任一订阅 source
-    存在检测框，就认为该帧 active；连续 active 帧合并为一个片段。
+    segment(model_input) 返回 List[SegmentFact]。只要某帧任一订阅 source 存在检测框，
+    就认为该帧 active；连续 active 帧合并为一个片段。
 """
 
 from __future__ import annotations
 
-from typing import Any, List, Mapping, Sequence
+from typing import Any, List, Sequence
 
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameFeature
 from app.services.inference.models import SegmentFact
 from app.services.inference.offline.segmenter import OfflineSegmenter
 
@@ -45,30 +44,23 @@ class BrushRulesSegmenter(OfflineSegmenter):
         self.label = label
         self.min_frames = max(1, int(min_frames))
 
-    def preprocess(
-        self, streams: Mapping[str, Sequence[FrameDetections]]
-    ) -> Mapping[str, Sequence[FrameDetections]]:
-        """Mock 不做特征工程，直接把原始检测序列交给规则逻辑。"""
-        return streams
+    def preprocess(self, frames: Sequence[FrameFeature]) -> Sequence[FrameFeature]:
+        """Mock 不做特征工程，直接把帧序列交给规则逻辑。"""
+        return frames
 
     def segment(self, model_input: Any) -> List[SegmentFact]:
-        streams: Mapping[str, Sequence[FrameDetections]] = model_input
-        active_by_ts: dict[float, bool] = {}
-        for src in self.subscribes:
-            for fd in streams.get(src, ()):
-                ts = float(fd.timestamp)
-                active_by_ts[ts] = active_by_ts.get(ts, False) or bool(fd.detections)
-
+        frames: Sequence[FrameFeature] = model_input
         segments: List[SegmentFact] = []
         run_start: float | None = None
         run_last = 0.0
         run_count = 0
-        for ts in sorted(active_by_ts):
-            if active_by_ts[ts]:
+        for ff in frames:  # load 已按 ts 升序
+            active = any(fd.detections for fd in ff.by_source.values())
+            if active:
                 if run_start is None:
-                    run_start = ts
+                    run_start = ff.ts
                     run_count = 0
-                run_last = ts
+                run_last = ff.ts
                 run_count += 1
                 continue
 

--- a/app/services/inference/temporal/__init__.py
+++ b/app/services/inference/temporal/__init__.py
@@ -1,6 +1,6 @@
 """时序分析层 (L3/L4)。
 
-抽象：Operator / AlignedFrame（operator.py，合并 analyze 推进状态 + judge 出告警）
+抽象：Operator（operator.py，合并 analyze 推进状态 + judge 出告警；消费帧窗 List[FrameFeature]）
 处理流程：ClientTemporalActor 每 Client 1Hz tick（actor.py）→ 告警经 alarm_sink.persist_alarms
 过闸 + 落库（alarm_sink.py 编排 client 侧过闸 + persistence 无状态落库；actor 只在产出处把
 stage 别名烧进 alarm.stage）。

--- a/app/services/inference/temporal/actor.py
+++ b/app/services/inference/temporal/actor.py
@@ -98,11 +98,11 @@ class ClientTemporalActor:
         all_events: List[str] = []
         all_alarms: List[Alarm] = []
 
+        # 帧窗快照（List[FrameFeature]，多流已在写回口对齐）——各算子自行 _clip / 投影订阅流。
+        windows = self._cq.get_slide_window()
         for op in self._operators:
             try:
-                # 按 subscribes 收集各订阅流的滑窗快照（流名 = detector.name）
-                windows = {src: self._cq.get_slide_window(src) for src in op.subscribes}
-                if not any(windows.values()):
+                if not windows:
                     continue
                 op.analyze(windows)                 # 推进共享状态 _sm
                 events, alarms = op.judge()         # 读 _sm 出 overlay + 告警

--- a/app/services/inference/temporal/operator.py
+++ b/app/services/inference/temporal/operator.py
@@ -20,21 +20,12 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.domain.alarm import Alarm
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameDetections, FrameFeature
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class AlignedFrame:
-    """多流按 ts 对齐后的一帧：同一 ts 下各订阅流的 FrameDetections。"""
-
-    ts: float
-    by_source: Dict[str, FrameDetections]
 
 
 class Operator(ABC):
@@ -50,8 +41,8 @@ class Operator(ABC):
 
     # ── 两接口（共享 self._sm）────────────────────────────────
     @abstractmethod
-    def analyze(self, windows: Dict[str, List[FrameDetections]]) -> None:
-        """消费订阅流、推进 self._sm。windows: {流名: 该流滑窗快照(按 ts 升序)}。"""
+    def analyze(self, windows: List[FrameFeature]) -> None:
+        """消费帧窗、推进 self._sm。windows: 帧级 FrameFeature 快照(按 ts 升序，多流已对齐)。"""
 
     @abstractmethod
     def judge(self) -> Tuple[List[str], List[Alarm]]:
@@ -62,35 +53,20 @@ class Operator(ABC):
         return []
 
     # ── 基类工具 ─────────────────────────────────────────────
-    def _clip(self, window: List[FrameDetections]) -> List[FrameDetections]:
-        """把流裁到本算子感受野（保留 ts >= latest - window_seconds）。"""
+    def _clip(self, window: List[FrameFeature]) -> List[FrameFeature]:
+        """把帧窗裁到本算子感受野（保留 ts >= latest - window_seconds）。"""
         if not window:
             return []
-        cutoff = window[-1].timestamp - self.window_seconds
-        return [d for d in window if d.timestamp >= cutoff]
+        cutoff = window[-1].ts - self.window_seconds
+        return [f for f in window if f.ts >= cutoff]
 
-    def primary_window(
-        self, windows: Dict[str, List[FrameDetections]]
-    ) -> List[FrameDetections]:
-        """单订阅便捷：取首个订阅流并裁到感受野。"""
-        return self._clip(windows.get(self.subscribes[0], []))
-
-    def _zip_by_ts(
-        self, windows: Dict[str, List[FrameDetections]]
-    ) -> List[AlignedFrame]:
-        """多流按 ts 对齐（inner-join：仅保留所有订阅流都到齐的 ts）。
-
-        依赖不变式：同帧多流的 ts 完全相等（来自同一 FrameInference.timestamp），
-        故可用 ts 做精确 key。缺帧/错帧的 ts 被丢弃（latest-wins 等策略留子类 override）。
-        """
-        clipped = {s: self._clip(windows.get(s, [])) for s in self.subscribes}
-        if any(not w for w in clipped.values()):
-            return []
-        indexed = {s: {d.timestamp: d for d in w} for s, w in clipped.items()}
-        common = set.intersection(*(set(idx.keys()) for idx in indexed.values()))
+    def primary_window(self, windows: List[FrameFeature]) -> List[FrameDetections]:
+        """单订阅便捷：裁到感受野后投影首个订阅流的逐帧 FrameDetections。"""
+        src = self.subscribes[0]
         return [
-            AlignedFrame(ts=ts, by_source={s: indexed[s][ts] for s in self.subscribes})
-            for ts in sorted(common)
+            f.by_source[src]
+            for f in self._clip(windows)
+            if f.by_source.get(src) is not None
         ]
 
 

--- a/app/services/inference/visualization/worker.py
+++ b/app/services/inference/visualization/worker.py
@@ -20,12 +20,11 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameDetections, FrameFeature
 from app.domain.render import RenderSpec
 from app.domain.frame import Frame
 from app.services.inference.naming import get_stage_alias
 from app.services.client import client_manager
-from app.services.inference.models import FrameInference
 from app.services.inference.visualization.visualizer import FixedVisualizer
 
 logger = logging.getLogger(__name__)
@@ -126,13 +125,13 @@ class VisualizationWorker:
     def _process_client(self, task_id: int, cq) -> None:
         """处理单个 run 的可视化。"""
         # 1. 原子读取推理快照（所有 task 同帧一致）
-        inference: Optional[FrameInference] = cq.get_latest_inference()
+        inference: Optional[FrameFeature] = cq.get_latest_inference()
         if inference is None:
             return
 
         # 2. 去重：跳过已渲染过的同一推理结果
         last_ts = self._last_rendered_ts.get(task_id, 0.0)
-        if inference.timestamp <= last_ts:
+        if inference.ts <= last_ts:
             # 有推理快照但无新结果 → tick 空转。占比高即"上游供帧慢"的直接信号。
             self._stat_stale[task_id] += 1
             return
@@ -145,10 +144,10 @@ class VisualizationWorker:
         # 4. 获取最新时序事件
         events = cq.get_latest_temporal()
 
-        # 5. 渲染（计时，用于判定是否 render-bound）
-        stage = inference.stage
+        # 5. 渲染（计时，用于判定是否 render-bound）。stage 取自 cq 不可变身份（快照不再携 stage）。
+        stage = cq.stage
         t0 = time.perf_counter()
-        annotated_frame = self._render(frame, stage, inference.detections, events)
+        annotated_frame = self._render(frame, stage, inference.by_source, events)
         dt = time.perf_counter() - t0
         self._render_time_sum += dt
         self._render_calls += 1
@@ -157,14 +156,14 @@ class VisualizationWorker:
 
         # 6. 写回
         frame_data = Frame(
-            timestamp=inference.timestamp,
+            timestamp=inference.ts,
             frame=annotated_frame,
         )
         cq.append_ca_processed(frame_data)
         cq.set_latest_rendered(frame_data)
 
         # 7. 更新去重时间戳 + 计成帧数（实际渲染帧数 = processed 真实成帧率）
-        self._last_rendered_ts[task_id] = inference.timestamp
+        self._last_rendered_ts[task_id] = inference.ts
         self._stat_rendered[task_id] += 1
 
     def _render(

--- a/app/services/inference/workflows/__init__.py
+++ b/app/services/inference/workflows/__init__.py
@@ -2,7 +2,7 @@
 
 抽象基类已上移分层包：
     流源 Detector / YOLODetector → app.services.inference.detection.detector
-    流算子 Operator / AlignedFrame → app.services.inference.temporal.operator
+    流算子 Operator → app.services.inference.temporal.operator
 
 本目录只放具体检测任务（一任务一文件）：
     Detector（流源，无状态）：BubbleDetector, BendingDetector, MockDetector,

--- a/app/services/inference/workflows/bending.py
+++ b/app/services/inference/workflows/bending.py
@@ -13,12 +13,12 @@ BendingOperator（时序线程，流算子）：
 """
 
 import logging
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 from app.services.inference.detection.detector import YOLODetector
 from app.services.inference.temporal.operator import Operator
 from app.domain.alarm import Alarm, AlarmMetric, AlarmType
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameDetections, FrameFeature
 from app.domain.render import RenderItem, RenderSpec, RenderType
 
 logger = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class BendingOperator(Operator):
             "last_ts": 0.0,
         }
 
-    def analyze(self, windows: Dict[str, List[FrameDetections]]) -> None:
+    def analyze(self, windows: List[FrameFeature]) -> None:
         window = self.primary_window(windows)
         if not window:
             return

--- a/app/services/inference/workflows/bubble.py
+++ b/app/services/inference/workflows/bubble.py
@@ -13,14 +13,14 @@ BubbleOperator（时序线程，流算子）：
 
 import logging
 from types import SimpleNamespace
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 
 from app.services.inference.detection.detector import YOLODetector
 from app.services.inference.temporal.operator import Operator
 from app.domain.alarm import Alarm, AlarmMetric, AlarmType
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameDetections, FrameFeature
 from app.domain.render import RenderItem, RenderSpec, RenderType
 
 logger = logging.getLogger(__name__)
@@ -151,7 +151,7 @@ class BubbleOperator(Operator):
             "alarming": False,
         }
 
-    def analyze(self, windows: Dict[str, List[FrameDetections]]) -> None:
+    def analyze(self, windows: List[FrameFeature]) -> None:
         window = self.primary_window(windows)
         if not window:
             return

--- a/app/services/inference/workflows/claude.md
+++ b/app/services/inference/workflows/claude.md
@@ -32,11 +32,12 @@ flowchart TD
 
 | 角色 | 基类 | 职责 | 状态机 |
 | -- | ---- | ---- | ------ |
-| 流源 | `Detector` / `YOLODetector` | 单帧检测，bbox=特征。无状态，多 Client 共享；`name` = 该 detector 产出的流名（slide_window key） | 无 |
-| 流算子 | `Operator` | 合并 analyze+judge，单 `_sm`：`analyze(windows)` 按 `subscribes` 收订阅流、`_clip` 到 `window_seconds` 感受野、推进 `_sm`；`judge()` 读 `_sm` 出 (overlay 文案, 告警)；`finalize()` 结算。一个 Operator = 一条规则，每 Client 独立 | 共享状态机 `self._sm`（测量 + 决策同一份） |
+| 流源 | `Detector` / `YOLODetector` | 单帧检测，bbox=特征。无状态，多 Client 共享；`name` = 该 detector 产出的流名（= `FrameFeature.by_source` 的 key） | 无 |
+| 流算子 | `Operator` | 合并 analyze+judge，单 `_sm`：`analyze(windows: List[FrameFeature])` `_clip` 到 `window_seconds` 感受野、按 `subscribes` 从 `by_source` 取订阅流、推进 `_sm`；`judge()` 读 `_sm` 出 (overlay 文案, 告警)；`finalize()` 结算。一个 Operator = 一条规则，每 Client 独立 | 共享状态机 `self._sm`（测量 + 决策同一份） |
 
 > `name`（算子自身/输出身份）与 `subscribes`（输入流清单，显式必填）正交：算子名 ≠ 流名。
-> 多订阅算子用基类 `_zip_by_ts` 按 ts inner-join 对齐多流（同帧 ts 精确相等）。
+> 多流对齐在**写回口**一次完成：整帧 `FrameInference` 物化成帧级 `FrameFeature`（`ts + {流名: FrameDetections}`），
+> 算子直接读 `by_source`，无需 zip（单订阅用基类 `primary_window` 投影自身流）。
 > 阈值/required 归算子自身字段；`AlarmInfo.metric` 由算子显式填，不依赖 name。
 
 特征由推理写回处常开落盘到 `FeatureStore`（`{task_id}/{step_id}/features.jsonl`，与 HLS 同款工作目录，按帧 `ts` 对齐）。实时链路**不落盘事实**（已无 EventFact 对象间传输，状态共享于 `_sm`）；`FactLedger`（`{task_id}/{step_id}/facts.jsonl`）为 offline 预置，待离线 segmenter 接入后写 `SegmentFact`。

--- a/app/services/inference/workflows/clean.py
+++ b/app/services/inference/workflows/clean.py
@@ -178,17 +178,15 @@ class CleanOperator(TemporalOperator):
             # 保证特征行数与 aligned_frames 严格一一对应，时间轴不缺帧。
             feature = [[0.0] * num_features_per_object for _ in range(self.num_objects)]
 
+            # 帧级分辨率（同帧各流同值）读一次：缺失/非法则本帧留全零行，不进 by_source。
+            width, height = aligned.frame_width, aligned.frame_height
+            if not width or not height or width <= 0 or height <= 0:
+                features.append(feature)
+                continue
+
             for frame in aligned.by_source.values():
                 # 跳过检测层推理失败的帧（不参与特征，留零贡献）
                 if not frame.success:
-                    continue
-                shape = frame.metadata.get("frame_shape")
-                if not shape or len(shape) != 3:
-                    # 目前仅支持 (H, W, C) 格式
-                    continue
-                height, width, _ = shape
-                if width <= 0 or height <= 0:
-                    # 忽略无效图像尺寸
                     continue
 
                 if not frame.detections:

--- a/app/services/inference/workflows/clean.py
+++ b/app/services/inference/workflows/clean.py
@@ -18,9 +18,9 @@ from typing import Dict, List, Tuple
 import torch
 
 from app.services.inference.detection.detector import YOLODetector
-from app.services.inference.temporal.operator import AlignedFrame, TemporalOperator
+from app.services.inference.temporal.operator import TemporalOperator
 from app.domain.alarm import Alarm
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameDetections, FrameFeature
 from app.domain.render import RenderItem, RenderSpec, RenderType
 
 # 固定调色板，按 class_id 取色（BGR）
@@ -126,12 +126,11 @@ class CleanOperator(TemporalOperator):
             "latest_action": 0,
         }
 
-    def analyze(self, windows: Dict[str, List[FrameDetections]]) -> None:
-        """消费订阅流、推进 self._sm。windows: {流名: 该流滑窗快照(按 ts 升序)}。"""
-        # 按 timestamp 对齐多流
-        aligned_frames = self._zip_by_ts(windows)
+    def analyze(self, windows: List[FrameFeature]) -> None:
+        """消费帧窗、推进 self._sm。windows: 帧级 FrameFeature 快照(按 ts 升序，多流已对齐)。"""
+        aligned_frames = self._clip(windows)
         if not aligned_frames:
-            return        
+            return
         self._advance(aligned_frames)
 
     def judge(self) -> Tuple[List[str], List[Alarm]]:
@@ -140,7 +139,7 @@ class CleanOperator(TemporalOperator):
         alarms = []
         return events, alarms
 
-    def _advance(self, aligned_frames: List[AlignedFrame]) -> None:
+    def _advance(self, aligned_frames: List[FrameFeature]) -> None:
         """推进 self._sm。aligned_frames: 对齐后的窗口快照列表。"""
         last_ts = self._sm["last_ts"]
         new_frames = [f for f in aligned_frames if f.ts > last_ts]
@@ -158,7 +157,7 @@ class CleanOperator(TemporalOperator):
         self._sm["latest_action"] = logits[-1, :].argmax().item()
         self._sm["last_ts"] = new_frames[-1].ts
 
-    def _adapt_to_features(self, aligned_frames: List[AlignedFrame]) -> torch.Tensor:
+    def _adapt_to_features(self, aligned_frames: List[FrameFeature]) -> torch.Tensor:
         """将窗口快照转换为特征矩阵。
 
         同一原始帧的多流检测结果合并到同一个 feature vector 中。

--- a/app/services/inference/workflows/mock.py
+++ b/app/services/inference/workflows/mock.py
@@ -71,7 +71,6 @@ class MockDetector(Detector):
             detections=detections,
             metadata={
                 "model": "mock_brightness",
-                "frame_shape": frame.shape,
                 "mean_brightness": round(mean_brightness, 2),
             },
             timestamp=timestamp,

--- a/app/services/inference/workflows/mock.py
+++ b/app/services/inference/workflows/mock.py
@@ -14,14 +14,14 @@ MockOperator（时序线程，流算子）：
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 
 from app.services.inference.detection.detector import Detector
 from app.services.inference.temporal.operator import Operator
 from app.domain.alarm import Alarm, AlarmType
-from app.domain.detection import Detection, FrameDetections
+from app.domain.detection import Detection, FrameDetections, FrameFeature
 from app.domain.render import RenderItem, RenderSpec, RenderType
 
 logger = logging.getLogger(__name__)
@@ -151,7 +151,7 @@ class MockOperator(Operator):
             "alarm_count": 0,
         }
 
-    def analyze(self, windows: Dict[str, List[FrameDetections]]) -> None:
+    def analyze(self, windows: List[FrameFeature]) -> None:
         window = self.primary_window(windows)
         if not window:
             return

--- a/docs/kb/DESIGN_CONCURRENCY_AND_QUEUES.md
+++ b/docs/kb/DESIGN_CONCURRENCY_AND_QUEUES.md
@@ -30,20 +30,20 @@ per-task 生命周期事务锁**收敛为一把** `RLock`，由 `ClientManager.l
 
 ### ClientQueues 锁库存
 
-ClientQueues 中的锁按职责拆分：
+ClientQueues 中的锁按职责拆分（身份 `task_id/step_id/stage/task_started_at` 为构造定死的不可变
+primitive，热路径免锁直读，故**无** `_task_lock`——原历史锁已删）：
 
-- `_task_lock`：task 和 task_started_at。
 - `_raw_lock`：raw queue 和 latest raw。
 - `_viz_lock`：processed queue 和 latest rendered。
-- `_inference_lock`：latest inference。
-- `_frontend_lock`：stage 和 latest temporal。
-- `_slide_window_lock`：检测滑动窗口。
+- `_inference_lock`：latest inference（帧级 `FrameFeature` 原子快照）。
+- `_frontend_lock`：latest temporal。
+- `_slide_window_lock`：帧级 `FrameFeature` 滑窗（一帧一条，多流已对齐）。
 - `_alarm_lock`：alarm log、seq、gate。
 
-clear 时固定顺序：
+clear 时固定顺序（6 把 payload 锁）：
 
 ```text
-_task_lock -> _raw_lock -> _viz_lock -> _inference_lock
+_raw_lock -> _viz_lock -> _inference_lock
 -> _frontend_lock -> _slide_window_lock -> _alarm_lock
 ```
 

--- a/docs/kb/SERVICE_INFERENCE.md
+++ b/docs/kb/SERVICE_INFERENCE.md
@@ -21,7 +21,7 @@
 | `visualization/worker.py` | Viz | `VisualizationWorker` | 读快照渲染，写 `ca_processed` + `_latest_rendered` |
 | `visualization/visualizer.py` | Viz | `FixedVisualizer` | 按 `RenderSpec` 固定渲染 |
 | `workflows/` | 接入点 | bubble/bending/clean/mock | 具体 Detector + Operator 子类 |
-| `offline/` | 离线 | —（仅 `__init__` 占位） | **待实现**：Segmenter/Runner 读 FeatureStore→写 FactLedger |
+| `offline/` | 离线 | `OfflineSegmenter`/`OfflineRunner` + `segmenters/{clean,mock}` + `cli` | 独立进程读 `FeatureStore.load`→策略 `preprocess`/`segment`→写 `FactLedger`（详见 online/offline 分离） |
 
 ## InferenceManager（生命周期编排）
 
@@ -41,7 +41,7 @@
 
 1. `cq.push_detection(FrameFeature(ts=res.timestamp, by_source=res.detections))` → 帧级 `_slide_window`（`Deque[FrameFeature]`，写回口一次物化整帧多流；供 L3，异步缓冲解速差 30fps↔1Hz）。
 2. `cq.set_latest_inference(feature)` → 原子快照（同一 `FrameFeature`，供 Viz；无 `cq`，不成自引用环。Viz 的 stage 取自 `cq.stage`）。
-3. `feature_store.append(task_id, step_id, res, owner=cq)` → L2 落盘（供离线）。
+3. `feature_store.append(task_id, step_id, feature, owner=cq)` → L2 落盘同一份帧级 `FrameFeature`（供离线；两端货币一致）。
 
 全程携 CQ 句柄（`res.cq`，dispatcher pop 时捕获），**无 `client_id` 反查**。
 
@@ -60,7 +60,7 @@ per-run daemon 线程，`stop_event.wait(tick_interval)` 节奏。每 tick 取�
 
 ## online / offline 分离
 
-实时链（L1→`_slide_window`→L3 tick 1Hz）与离线链（`FeatureStore.load` → OfflineSegmenter → FactLedger）**彻底分离**：实时不落 FactLedger，Actor 不 load 事实。当前 `offline/` 仅占位，消费端（Segmenter/Runner）**待实现**（见 `docs/update/20260628_OFFLINE_PIPELINE_PHASE1_PROPOSAL.md`）。
+实时链（L1→`_slide_window`→L3 tick 1Hz）与离线链（`FeatureStore.load` → OfflineSegmenter → FactLedger）**彻底分离**：实时不落 FactLedger，Actor 不 load 事实。两链共用一套货币 **帧级 `FrameFeature`**（`ts + {source: FrameDetections}`）：写回口 `append(feature)` 落盘，离线 `load(task_id, step_id) → List[FrameFeature]`（一次到位、多流已对齐）喂 `OfflineSegmenter.preprocess(frames)`。`offline/` 已接入（独立进程 CLI `python -m app.services.inference.offline.cli run`，见 `runner.py`/`segmenters/`）。
 
 ## Stage 配置与当前阶段
 

--- a/docs/kb/SERVICE_INFERENCE.md
+++ b/docs/kb/SERVICE_INFERENCE.md
@@ -39,20 +39,20 @@
 
 `ModelWorkerService._write_back_results(List[FrameInference])` 是 L1 唯一写回口。每条结果先判 `res.cq.is_active()`（DRAINING/CLOSED 丢弃 → `stale_run` 计数），ACTIVE 才三写：
 
-1. `cq.push_detection(detector_name, FrameDetections)` → per-stream `_slide_window`（供 L3，异步缓冲解速差 30fps↔1Hz）。
-2. `cq.set_latest_inference(res)` → 原子快照（供 Viz）。
+1. `cq.push_detection(FrameFeature(ts=res.timestamp, by_source=res.detections))` → 帧级 `_slide_window`（`Deque[FrameFeature]`，写回口一次物化整帧多流；供 L3，异步缓冲解速差 30fps↔1Hz）。
+2. `cq.set_latest_inference(feature)` → 原子快照（同一 `FrameFeature`，供 Viz；无 `cq`，不成自引用环。Viz 的 stage 取自 `cq.stage`）。
 3. `feature_store.append(task_id, step_id, res, owner=cq)` → L2 落盘（供离线）。
 
 全程携 CQ 句柄（`res.cq`，dispatcher pop 时捕获），**无 `client_id` 反查**。
 
 ## Detector / Operator 两粒度框架
 
-- **Detector**（流源，分组粒度，无状态共享）：`name`（= 产出流名 = slide_window key）、`infer_batch(frames, timestamps)`（**唯一推理入口**，无单帧 `infer()`）、`prepare_visualization_data`。`timestamps` 是帧捕获真值锚点（源自 `Frame.timestamp`，pool 从 `req.timestamp` 穿入），须原样写回 `FrameDetections.timestamp`，令每帧 `FrameDetections.timestamp == FrameInference.timestamp`，供 L3 `_zip_by_ts` 多流对齐——detector 不得自造时间戳。YOLO 类继承 `YOLODetector` 复用惰性加载/batch/CUDA 异常转换。
+- **Detector**（流源，分组粒度，无状态共享）：`name`（= 产出流名 = slide_window key）、`infer_batch(frames, timestamps)`（**唯一推理入口**，无单帧 `infer()`）、`prepare_visualization_data`。`timestamps` 是帧捕获真值锚点（源自 `Frame.timestamp`，pool 从 `req.timestamp` 穿入），须原样写回 `FrameDetections.timestamp`，令每帧 `FrameDetections.timestamp == FrameInference.timestamp`——写回口据此物化帧级 `FrameFeature` 对齐多流（供 L3），detector 不得自造时间戳。YOLO 类继承 `YOLODetector` 复用惰性加载/batch/CUDA 异常转换。
 - **Operator**（流算子，规则粒度，per-run 独立）：`name`、`subscribes`（**显式、必填**输入流名列表，缺则 fail-fast）、`window_seconds`；`analyze(windows)` 推进 `self._sm`、`judge() → (overlay_texts, alarms)`、`finalize() → List[Alarm]`（结算，默认空）。analyze+judge **合并**进 Operator（不再有独立 TemporalAnalyzer/Judge，不做 EventFact 跨对象传递）。
 
 ## L3/L4：ClientTemporalActor（~1Hz）
 
-per-run daemon 线程，`stop_event.wait(tick_interval)` 节奏。每 tick 对每个 operator：`windows = {src: cq.get_slide_window(src) for src in op.subscribes}` → `op.analyze(windows)` → `op.judge()` 收 (events, alarms)；汇总后 `cq.set_latest_temporal(events)`，`alarm_sink.persist_alarms(alarms, cq, mode=REALTIME)`。**per-operator 隔离**（单算子异常不断整 tick）。stage 别名在告警离开推理前烧进 `alarm.stage`。停机两段：`signal_stop()` → `finalize_and_stop() → List[Alarm]`（收各 operator `finalize()` 结算告警）。
+per-run daemon 线程，`stop_event.wait(tick_interval)` 节奏。每 tick 取一次帧窗 `windows = cq.get_slide_window()`（`List[FrameFeature]`，多流已在写回口对齐），对每个 operator：`op.analyze(windows)`（算子内自行 `_clip` + 按 `subscribes` 投影）→ `op.judge()` 收 (events, alarms)；汇总后 `cq.set_latest_temporal(events)`，`alarm_sink.persist_alarms(alarms, cq, mode=REALTIME)`。**per-operator 隔离**（单算子异常不断整 tick）。stage 别名在告警离开推理前烧进 `alarm.stage`。停机两段：`signal_stop()` → `finalize_and_stop() → List[Alarm]`（收各 operator `finalize()` 结算告警）。
 
 ## 告警落库：alarm_sink.persist_alarms
 

--- a/docs/update/20260717_FRAME_FEATURE_WINDOW.md
+++ b/docs/update/20260717_FRAME_FEATURE_WINDOW.md
@@ -1,0 +1,66 @@
+# 滑窗改帧级 FrameFeature：砍 `_zip_by_ts`，多流对齐上移写回口
+
+> **变更状态**：生效中（2026-07-17）
+> **知识库**：已沉淀 → [kb/SERVICE_INFERENCE.md](../kb/SERVICE_INFERENCE.md)(2026-07-17)
+>
+> 触发方案：[specs/INFERENCE_ENGINE_DESIGN.md](../../specs/INFERENCE_ENGINE_DESIGN.md) 讨论中的实时特征路收敛。
+> 承接：建立在「online/offline 分离 + FeatureStore 单源」之上。本次是「上游共享特征」落地的第一步（下一步：extract 抽取共享 + FeatureStore frame_shape 往返 + 离线 segmenter 复用）。
+
+## 概述
+
+- **改了什么**：`ClientQueues` 滑窗从 **per-stream `Dict[str, Deque[FrameDetections]]`** 改为 **单条帧级 `Deque[FrameFeature]`**；写回口把整帧 `FrameInference` 一次物化成 `FrameFeature`（`ts + {流名: FrameDetections}`，新增于领域层 [app/domain/detection.py](../../app/domain/detection.py)）；算子契约 `analyze` 改收 `List[FrameFeature]`；删除 `Operator._zip_by_ts` 与 `AlignedFrame`。
+- **为什么改**：同 stage 各 detector 跑同一批帧（`FrameInference` 已携整帧多流），旧路先 `push_detection` 逐 detector 拆成 per-stream、算子再 `_zip_by_ts` 按 ts inner-join 拼回——拆了又拼纯冗余；且动作识别不需要算子链/异构节奏对齐，zip 潜在价值不成立。
+- **影响面**：`queues`（窗口结构 + 4 个方法体，函数名全保留）、写回口 `service._write_back_results`、`operator` 基类契约、`actor._tick`、四个 workflow 算子、`signals_10s` 聚合内部实现。
+
+## 改动详情
+
+### 1. [app/domain/detection.py](../../app/domain/detection.py) — 新增 `FrameFeature`
+帧级多流对齐记录 `ts + by_source: {流名: FrameDetections}`；不含 `cq`，`client`/`inference`/`offline` 均 import 安全。持有对齐后的检测（非计算特征），张量化仍在算子内。
+
+### 2. [app/services/client/queues.py](../../app/services/client/queues.py) — 窗口改帧级（**函数名全保留**）
+- `_slide_window: Dict[str, Deque[FrameDetections]]` → `Deque[FrameFeature]`；删 `_stream_windows`；`_slide_window_seconds` 语义改为"帧窗保留时长"（= `max(10s 底线, 各算子最大感受野)`）；新增模块常量 `_SIGNALS_WINDOW_SEC = 10.0`。
+- `push_detection(task_name, output)` → `push_detection(feature: FrameFeature)`（一帧一次）。
+- `get_slide_window(task_name)` → `get_slide_window()`（返 `List[FrameFeature]`）。
+- `get_slide_window_summary` 重写：遍历帧窗、按 `by_source` 聚合，**固定 10s 底线裁窗**，输出格式 `{流名: {active, hit_count, max_conf}}` 不变（[app/routers/task.py](../../app/routers/task.py) 契约不动）。
+
+### 3. [service.py](../../app/services/inference/detection/service.py) `_write_back_results`
+per-detector `push_detection` 循环 → 保留 degraded 警告遍历 + 物化一份 `feature = FrameFeature(ts=res.timestamp, by_source=res.detections)`（共享 `res.detections` 引用，不复制），**帧窗 + 原子快照共用**：`cq.push_detection(feature)` + `cq.set_latest_inference(feature)`。`FrameInference` 退化为纯 pool→写回口传输消息，不再被 cq 留存 → 消除 `cq→_latest_inference→cq` 自引用环。
+
+### 3b. Viz 快照改吃 FrameFeature
+`_latest_inference: Optional[FrameFeature]`；`set/get_latest_inference` 类型改 `FrameFeature`（**函数名不变**）。[worker.py](../../app/services/inference/visualization/worker.py) 读 `inference.ts`/`.by_source`，stage 取自 `cq.stage`（不可变身份，快照不再携 stage）。
+
+### 4. [operator.py](../../app/services/inference/temporal/operator.py) — 契约帧级 + 删 zip
+删 `AlignedFrame` / `_zip_by_ts`；`analyze(windows: List[FrameFeature])`；`_clip` 按 `FrameFeature.ts` 裁；`primary_window` = 裁窗后投影首个订阅流的逐帧 `FrameDetections`。
+
+### 5. 算子接入点
+- bubble/bending/mock（[workflows](../../app/services/inference/workflows/)）：`analyze` 仅换类型注释 → `List[FrameFeature]`，`primary_window(windows)` 及体内逻辑逐字不变。
+- [clean.py](../../app/services/inference/workflows/clean.py) `CleanOperator.analyze`：`_zip_by_ts` → `_clip`，其余（`_advance`/`_adapt_to_features`）不变（`by_source`/`.ts` 对 `FrameFeature` 同构）。
+
+### 6. [actor.py](../../app/services/inference/temporal/actor.py) `_tick`
+循环前一次 `windows = cq.get_slide_window()`；各算子 `op.analyze(windows)` 自行 `_clip`/投影。删 per-op `{src: get_slide_window(src)}` 逐流构建。
+
+### 7. [queues.py](../../app/services/client/queues.py) — 顺手清理无效锁 `_task_lock`
+`_task_lock` 是历史遗留：身份 `task_id/step_id/stage/task_started_at` 早已是构造定死的不可变
+primitive、热路径免锁直读，该锁不再护任何状态。删除声明 + Lock Inventory 条目 + `_release_payload`
+持锁列表条目，payload 锁 **7 → 6**（`_release_payload` docstring / RunState 注释 / 锁库存注释同步改 6）。
+与本次帧窗改造无耦合，一并清理。
+
+### 保留项（不改动）
+- 函数名 `push_detection` / `get_slide_window` / `get_slide_window_summary` / `set_stream_windows` / `analyze` / `primary_window` / `_clip` 全保留（仅签名/体变），便于 diff 对应。
+- `set_latest_inference`（Viz 单槽）、`feature_store.append`（离线腿）不动。
+
+## 数据通道 / 行为说明
+
+| 通道 | 填充 | 消费 | 本次影响 |
+|------|------|------|---------|
+| `_slide_window`（帧级 FrameFeature） | 写回口 `push_detection` 一帧一次 | 算子 `analyze` + `signals_10s` 汇总 | 是（per-stream → 帧级；无 zip） |
+| `_latest_inference` | 写回口 `set_latest_inference` | Viz | 是（改存 `FrameFeature`，去自引用环；Viz stage 取 `cq.stage`） |
+| `FeatureStore` | 写回口 `feature_store.append` | 离线 | 否 |
+
+## 验证
+
+| 项 | 结果 |
+|----|------|
+| 全量 `pytest tests/` | 296 passed |
+| signals_10s 语义 | `get_slide_window_summary` 输出格式/键不变，固定 10s 底线；今无 stream 感受野 >10s 故逐值等价 |
+| 迁移单测 | 帧窗工厂 `make_frame_feature`（[tests/factories.py](../../tests/factories.py) 单源）；`_zip_by_ts` 用例改为验证写回口 `FrameFeature` 携全流 |

--- a/docs/update/20260717_FRAME_FEATURE_WINDOW.md
+++ b/docs/update/20260717_FRAME_FEATURE_WINDOW.md
@@ -57,6 +57,14 @@ primitive、热路径免锁直读，该锁不再护任何状态。删除声明 +
 | `_latest_inference` | 写回口 `set_latest_inference` | Viz | 是（改存 `FrameFeature`，去自引用环；Viz stage 取 `cq.stage`） |
 | `FeatureStore` | 写回口 `feature_store.append` | 离线 | 否 |
 
+### 窗口生命周期（冷启动语义）
+
+`_slide_window` 是**时间窗非计数窗**（`deque` 无 `maxlen`，`push_detection` 每帧 append 后按 `cutoff = ts - _slide_window_seconds` 即时淘汰左端）。因此：
+
+- **从第 1 帧写入即开始滚动、从空生长到稳态、永不"等满"**：早期历史不足 `window_seconds` 时 `cutoff` 落在所有帧之前、无可淘汰，窗口只是往上长；超过后尾部旧帧才开始 `popleft`。
+- **共享的是最新帧（右锚 `window[-1].ts`）不是读游标**：无 per-consumer / per-tick 读位置状态，`get_slide_window()` 每次返当前整条快照；各算子以右锚为**终点**、用自身 `window_seconds` 往回 `_clip` 取**不同长度**的历史。时序状态累积靠算子 `self._sm`，不靠队列位置——同一帧会被多个 tick 重叠读到（1Hz tick、帧率更高），是有意的重叠滑窗。
+- **驱动侧唯一门控是空/非空**（`actor._tick`：`if not windows: continue`），**不 gate 窗口是否"帧数够"**。冷启动阶段算子拿到的是不完整短窗——框架不替算子挡"帧数不足"；需完整感受野才有效的模型（如 MS-TCN，感受野 ≫ 窗口）须在 `analyze/judge` 内自行判 `len`/时间跨度短路，否则早期恒吐 Idle/垃圾。
+
 ## 验证
 
 | 项 | 结果 |

--- a/docs/update/20260720_FEATURE_STORE_FRAMEFEATURE_IO.md
+++ b/docs/update/20260720_FEATURE_STORE_FRAMEFEATURE_IO.md
@@ -2,29 +2,34 @@
 
 > 日期：2026-07-20　依据：代码改动
 
-在线滑窗/快照货币早已是帧级 `FrameFeature`（`ts + {source: FrameDetections}`），但 L2 落盘基座 `FeatureStore` 两端不对称：`append` 吃 `FrameInference`、`load`/`load_many` 吐 per-source `Dict[str, List[FrameDetections]]`。本次把两端 + 离线消费端统一到 `FrameFeature`。**磁盘格式 `{ts, features, wh}` 不变**（老 `features.jsonl` 兼容）。
+在线滑窗/快照货币早已是帧级 `FrameFeature`（`ts + {source: FrameDetections}` + 帧级 `frame_width/height`），但 L2 落盘基座 `FeatureStore` 两端不对称：`append` 吃 `FrameInference`、`load`/`load_many` 吐 per-source `Dict[str, List[FrameDetections]]`。本次把两端 + 离线消费端统一到 `FrameFeature`。磁盘 record 为 `{ts, features, frame_width?, frame_height?}`（帧分辨率全命名键、缺省省略，老 `features.jsonl` 兼容）。
 
 ## 改动
 
 ### 序列化（写入端）
-- [store.py](../../app/services/inference/feature/store.py) `append(feature: FrameFeature, ...)`：从 `feature.by_source`/`feature.ts` 序列化，`wh` 仍由 `_extract_frame_wh(feature.by_source)` 提取。
+- [store.py](../../app/services/inference/feature/store.py) `append(feature: FrameFeature, ...)` 经 `_feature_to_record`：`ts`/`by_source` → `{ts, features}`，`frame_width/height` 两者皆非 None 时落顶层全命名键。
 - [service.py](../../app/services/inference/detection/service.py) 写回口传 `feature`（帧窗/快照/落盘共用同一份，不再传 `res`）。`FrameInference` 彻底退化为 pool→写回口传输消息。
 
 ### 反序列化（读取端）
-- [store.py](../../app/services/inference/feature/store.py) **`load(task_id, step_id) -> List[FrameFeature]`** 一次到位替换旧 `load(source)`/`load_many`（**已删**）：单扫 `features.jsonl`，每行还原一个 `FrameFeature`（by_source 含该行全部 source，present-key 落在键集；`wh` 回填每个 `FrameDetections.metadata` 的 `frame_width/height`），按 ts 升序。无包装、无嵌套。
+- [store.py](../../app/services/inference/feature/store.py) **`load(task_id, step_id) -> List[FrameFeature]`** 一次到位替换旧 `load(source)`/`load_many`（**已删**）：单扫 `features.jsonl`，每行经 `_record_to_feature` 还原一个 `FrameFeature`（by_source 含该行全部 source，present-key 落在键集；`ts` 在此边界统一 `float`；`frame_width/height` 还原到 **`FrameFeature` 字段**，非 `FrameDetections.metadata`），按 ts 升序。无包装、无嵌套。
 
 ### 离线消费端（吃 FrameFeature）
 - [offline/segmenter.py](../../app/services/inference/offline/segmenter.py) 基类 `preprocess(self, frames: Sequence[FrameFeature])`。
-- [offline/segmenters/clean.py](../../app/services/inference/offline/segmenters/clean.py)：**`build_base_features` 直接吃 `Sequence[FrameFeature]`**（唯一调用点、无直测）——per-source 合并折进 `_collect_object_arrays` 的既有检测遍历（多一层 `by_source.values()`），`_frame_size` 从任一流 metadata 取宽高。preprocess 收敛成一行（**无 by_ts 融合、无中间 FrameDetections**）。`build_base_features` 之后的 recipe（113/121/249 维）零改动。
+- [offline/segmenters/clean.py](../../app/services/inference/offline/segmenters/clean.py)：**`build_base_features` 直接吃 `Sequence[FrameFeature]`**（唯一调用点、无直测）——per-source 合并折进 `_collect_object_arrays` 的既有检测遍历（多一层 `by_source.values()`），帧分辨率直接读 `FrameFeature.frame_width/height`（缺失回退传入默认，逻辑内联、无独立 `_frame_size` 函数）。**`transform_features` 已并入 `preprocess`**：base `preprocess` 只做 `build_base_features`（v2/113），ASFormer/BiGRU 覆盖 `preprocess` 经 `super().preprocess()` 叠 recipe（121/249）。`build_base_features` 之后的 recipe 函数（`add_business_priors`/`add_centered_window_stats`）零改动。
 - [offline/segmenters/mock.py](../../app/services/inference/offline/segmenters/mock.py)：preprocess 透传、segment 逐帧遍历 `by_source`。
 - [offline/runner.py](../../app/services/inference/offline/runner.py)：`frames = load(...)`；empty 判定改按 `by_source` 键集并集。
 
 ## 边界 / 不动
 - 改动止于各 segmenter `preprocess` 返回（segment/模型推理/解码不动）。
-- 在线 `CleanOperator._adapt_to_features`(6 维) 与离线 `build_base_features`(113+ 维) 仍是刻意分离的两条特征管线，**本次不统一**。metadata 键沿用离线读的 `frame_width/height`（在线用 `frame_shape`，两路不交叉）。
+- 在线 `CleanOperator._adapt_to_features`(6 维) 与离线 `build_base_features`(113+ 维) 仍是刻意分离的两条特征管线，**本次不统一**。帧分辨率现为 `FrameFeature` 帧级字段（pool 从原始帧盖章、store 往返还原），在线/离线同源。
+
+## 顺带清理（同批）
+- `_frame_size` 只一处调用 → 内联进 `_collect_object_arrays`，删函数。
+- `ts` 类型转换归到反序列化边界（`store.load`），`build_base_features` 去掉 `float(ff.ts)`。
+- inference 模块 import 全量扫描：删 4 处未用（`dispatcher.py` 的 `ClientQueues`、`manager.py` 的 `Tuple/Type/Union`）。
 
 ## 测试
-- `test_offline_pipeline`：`TestLoadMany`→`TestLoad`（断言 `List[FrameFeature]` + `wh` 往返）；直调 preprocess 的用例经本地 `_frames()` 由 per-source dict zip 成帧；假 segmenter 签名跟改。
+- `test_offline_pipeline`：`TestLoadMany`→`TestLoad`（断言 `List[FrameFeature]` + `frame_width/height` 往返到 `FrameFeature` 字段、`FrameDetections.metadata` 为空）；直调 preprocess 的用例经本地 `_frames()` 由 per-source dict zip 成帧；假 segmenter 签名跟改。
 - `test_offline_reservation`/`test_feature_store_owner_fence`：`append(FrameFeature)` + `load()` 后按 `by_source[src]` 断言。
 - `test_writeback_handle_fence`：spy 断言落盘键 + `by_source is res.detections`。
 - `pytest tests/` **335 passed**。

--- a/docs/update/20260720_FEATURE_STORE_FRAMEFEATURE_IO.md
+++ b/docs/update/20260720_FEATURE_STORE_FRAMEFEATURE_IO.md
@@ -1,0 +1,30 @@
+# FeatureStore 序列化/反序列化统一到 FrameFeature（离线打通）
+
+> 日期：2026-07-20　依据：代码改动
+
+在线滑窗/快照货币早已是帧级 `FrameFeature`（`ts + {source: FrameDetections}`），但 L2 落盘基座 `FeatureStore` 两端不对称：`append` 吃 `FrameInference`、`load`/`load_many` 吐 per-source `Dict[str, List[FrameDetections]]`。本次把两端 + 离线消费端统一到 `FrameFeature`。**磁盘格式 `{ts, features, wh}` 不变**（老 `features.jsonl` 兼容）。
+
+## 改动
+
+### 序列化（写入端）
+- [store.py](../../app/services/inference/feature/store.py) `append(feature: FrameFeature, ...)`：从 `feature.by_source`/`feature.ts` 序列化，`wh` 仍由 `_extract_frame_wh(feature.by_source)` 提取。
+- [service.py](../../app/services/inference/detection/service.py) 写回口传 `feature`（帧窗/快照/落盘共用同一份，不再传 `res`）。`FrameInference` 彻底退化为 pool→写回口传输消息。
+
+### 反序列化（读取端）
+- [store.py](../../app/services/inference/feature/store.py) **`load(task_id, step_id) -> List[FrameFeature]`** 一次到位替换旧 `load(source)`/`load_many`（**已删**）：单扫 `features.jsonl`，每行还原一个 `FrameFeature`（by_source 含该行全部 source，present-key 落在键集；`wh` 回填每个 `FrameDetections.metadata` 的 `frame_width/height`），按 ts 升序。无包装、无嵌套。
+
+### 离线消费端（吃 FrameFeature）
+- [offline/segmenter.py](../../app/services/inference/offline/segmenter.py) 基类 `preprocess(self, frames: Sequence[FrameFeature])`。
+- [offline/segmenters/clean.py](../../app/services/inference/offline/segmenters/clean.py)：**`build_base_features` 直接吃 `Sequence[FrameFeature]`**（唯一调用点、无直测）——per-source 合并折进 `_collect_object_arrays` 的既有检测遍历（多一层 `by_source.values()`），`_frame_size` 从任一流 metadata 取宽高。preprocess 收敛成一行（**无 by_ts 融合、无中间 FrameDetections**）。`build_base_features` 之后的 recipe（113/121/249 维）零改动。
+- [offline/segmenters/mock.py](../../app/services/inference/offline/segmenters/mock.py)：preprocess 透传、segment 逐帧遍历 `by_source`。
+- [offline/runner.py](../../app/services/inference/offline/runner.py)：`frames = load(...)`；empty 判定改按 `by_source` 键集并集。
+
+## 边界 / 不动
+- 改动止于各 segmenter `preprocess` 返回（segment/模型推理/解码不动）。
+- 在线 `CleanOperator._adapt_to_features`(6 维) 与离线 `build_base_features`(113+ 维) 仍是刻意分离的两条特征管线，**本次不统一**。metadata 键沿用离线读的 `frame_width/height`（在线用 `frame_shape`，两路不交叉）。
+
+## 测试
+- `test_offline_pipeline`：`TestLoadMany`→`TestLoad`（断言 `List[FrameFeature]` + `wh` 往返）；直调 preprocess 的用例经本地 `_frames()` 由 per-source dict zip 成帧；假 segmenter 签名跟改。
+- `test_offline_reservation`/`test_feature_store_owner_fence`：`append(FrameFeature)` + `load()` 后按 `by_source[src]` 断言。
+- `test_writeback_handle_fence`：spy 断言落盘键 + `by_source is res.detections`。
+- `pytest tests/` **335 passed**。

--- a/docs/update/20260720_FRAME_WH_CARRYTHROUGH.md
+++ b/docs/update/20260720_FRAME_WH_CARRYTHROUGH.md
@@ -4,9 +4,11 @@
 
 `frame_shape`（帧分辨率）是 **fan-out 之前就定死的每帧输入常量**（一个 `DetectionTask` 扇给 stage 内 N 个模型，各流看同一张图），却被当作检测器输出逐个塞进 `FrameDetections.metadata`，落盘时再用 `_extract_frame_wh` 从任一检测器抠回、回读时还原成另一个名字 `frame_width/frame_height`——一个每帧常量穿过 fan-out 复制 N 份再收敛回 1 份，且 online 读 `frame_shape`、offline 读 `frame_width`，两处消费不对称。
 
-本次让分辨率沿**每帧轴**透传：pool 在帧还活着时盖一次章 → `FrameInference` → 写回口物化进 `FrameFeature` → 落盘/回读走 record 级 `wh`（磁盘格式 `{ts, features, wh}` 不变，老 `features.jsonl` 兼容）。**这取代了上一篇里 `_extract_frame_wh` + metadata 回填 `frame_width/height` 的做法。**
+本次让分辨率沿**每帧轴**透传：pool 在帧还活着时盖一次章 → `FrameInference` → 写回口物化进 `FrameFeature` → 落盘/回读随 record 走。**这取代了上一篇里 `_extract_frame_wh` + metadata 回填 `frame_width/height` 的做法。**
 
-约定：内存契约拆成 **`frame_width: Optional[int]` + `frame_height: Optional[int]`** 两个显式字段（不用 `(w,h)` 元组，避免隐式序混淆——本仓库已有 frame_shape(H,W,C)/wh(W,H)/frame_width 名义打架的前车之鉴）；缺省 None → 消费方走默认兜底。磁盘仍用紧凑数组 `wh=[width,height]`，位置约定就地锁在 store 序列化/反序列化各一处、不外泄。
+约定：内存契约拆成 **`frame_width: Optional[int]` + `frame_height: Optional[int]`** 两个显式字段（不用 `(w,h)` 元组，避免隐式序混淆——本仓库已有 frame_shape(H,W,C)/wh(W,H)/frame_width 名义打架的前车之鉴）；缺省 None → 消费方走默认兜底。磁盘同样用命名键 `frame_width/frame_height`（不再用位置数组 `wh`），全链路无位置约定。
+
+顺带把 store 的落盘/回读收成一对**对称映射** `_feature_to_record`/`_record_to_feature`（紧挨放置、互为逆），`append`/`load` 只做缓冲与扫描、委托它们做字段映射。磁盘 record 明确是 FrameFeature 的**精简投影**：只落离线必要信息（ts + 每源 bbox/conf/cls + 分辨率），**刻意不落** mask/keypoints（重）与 metadata/success/error（离线不消费），回读按契约默认还原。
 
 ## 改动
 
@@ -24,11 +26,11 @@
 
 ### 消费端改读帧级分辨率
 - online [workflows/clean.py](../../app/services/inference/workflows/clean.py) `_adapt_to_features`：分辨率从「by_source 内逐 source 读 `frame_shape`」改成「`for aligned` 顶部读一次 `aligned.frame_width/height`」，缺失/非法则该帧留全零行。
-- [store.py](../../app/services/inference/feature/store.py)：`append` 从 `feature.frame_width/height` 写磁盘 `wh` 数组；`load` 把 record `wh` 还原到 `FrameFeature.frame_width/height`（不再灌 metadata）；**删 `_extract_frame_wh`**。
+- [store.py](../../app/services/inference/feature/store.py)：落盘/回读收成对称映射 `_feature_to_record`/`_record_to_feature`（磁盘命名键 `frame_width/frame_height`，不再灌 metadata）；**删 `_extract_frame_wh`**。
 - offline [offline/segmenters/clean.py](../../app/services/inference/offline/segmenters/clean.py) `_frame_size`：读 `frame.frame_width/height`，缺失回退默认。
 
 ## 边界 / 不动
-- 磁盘格式与老文件兼容，无数据迁移；无 `wh` 的更老记录 → `frame_width/height=None` → offline 默认兜底（行为不变）。该兜底非冗余：离线 segmenter 的可配置默认分辨率（`stage_factory` **params）与 wh-less 测试数据都走它。
+- 磁盘键从位置数组 `wh` 改成命名 `frame_width/frame_height`：features.jsonl 是 `{task_id}/{step_id}/` 工作目录下随 step **TTL 回收**的临时件、且每 run 重生，故不做迁移；极端情况（run 跨部署、旧 `wh` 行被新码读）→ 该行分辨率缺失 → offline 默认兜底（无 crash，仅该 step 用默认尺寸归一化）。该默认兜底非冗余：离线 segmenter 的可配置默认分辨率（`stage_factory` **params）与无分辨率的测试数据都走它。
 - online（6 维）与 offline（113+ 维）两条特征管线仍刻意分离，本次只统一分辨率来源为 `FrameFeature.frame_width/height`（消解上一篇 `frame_shape`/`frame_width` 名不一致）。
 
 ## 测试

--- a/docs/update/20260720_FRAME_WH_CARRYTHROUGH.md
+++ b/docs/update/20260720_FRAME_WH_CARRYTHROUGH.md
@@ -1,0 +1,38 @@
+# 帧分辨率从 metadata 提升为帧级透传 wh
+
+> 日期：2026-07-20　依据：代码改动　承接：[20260720_FEATURE_STORE_FRAMEFEATURE_IO](20260720_FEATURE_STORE_FRAMEFEATURE_IO.md)
+
+`frame_shape`（帧分辨率）是 **fan-out 之前就定死的每帧输入常量**（一个 `DetectionTask` 扇给 stage 内 N 个模型，各流看同一张图），却被当作检测器输出逐个塞进 `FrameDetections.metadata`，落盘时再用 `_extract_frame_wh` 从任一检测器抠回、回读时还原成另一个名字 `frame_width/frame_height`——一个每帧常量穿过 fan-out 复制 N 份再收敛回 1 份，且 online 读 `frame_shape`、offline 读 `frame_width`，两处消费不对称。
+
+本次让分辨率沿**每帧轴**透传：pool 在帧还活着时盖一次章 → `FrameInference` → 写回口物化进 `FrameFeature` → 落盘/回读走 record 级 `wh`（磁盘格式 `{ts, features, wh}` 不变，老 `features.jsonl` 兼容）。**这取代了上一篇里 `_extract_frame_wh` + metadata 回填 `frame_width/height` 的做法。**
+
+约定：内存契约拆成 **`frame_width: Optional[int]` + `frame_height: Optional[int]`** 两个显式字段（不用 `(w,h)` 元组，避免隐式序混淆——本仓库已有 frame_shape(H,W,C)/wh(W,H)/frame_width 名义打架的前车之鉴）；缺省 None → 消费方走默认兜底。磁盘仍用紧凑数组 `wh=[width,height]`，位置约定就地锁在 store 序列化/反序列化各一处、不外泄。
+
+## 改动
+
+### 契约加透传字段
+- [detection.py](../../app/domain/detection.py) `FrameFeature` + `frame_width`/`frame_height`（帧级分辨率）。
+- [models.py](../../app/services/inference/models.py) `FrameInference` + `frame_width`/`frame_height`（pool 盖章、随传输消息透传）。
+- `FrameDetections` **结构不动**——`metadata` 继续装真·检测器级数据（`model`/`error`/`mean_brightness`）。
+
+### 盖章 / 物化
+- [pool.py](../../app/services/inference/detection/pool.py) 构造 `FrameInference` 时 `frame_width=frame.shape[1], frame_height=frame.shape[0]`——唯一采集点（原始帧此后即销毁）。
+- [service.py](../../app/services/inference/detection/service.py) 写回口 `FrameFeature(..., frame_width=res.frame_width, frame_height=res.frame_height)`。
+
+### 检测器停产 frame_shape
+- [detector.py](../../app/services/inference/detection/detector.py)、[workflows/mock.py](../../app/services/inference/workflows/mock.py)：metadata 去掉 `frame_shape`。
+
+### 消费端改读帧级分辨率
+- online [workflows/clean.py](../../app/services/inference/workflows/clean.py) `_adapt_to_features`：分辨率从「by_source 内逐 source 读 `frame_shape`」改成「`for aligned` 顶部读一次 `aligned.frame_width/height`」，缺失/非法则该帧留全零行。
+- [store.py](../../app/services/inference/feature/store.py)：`append` 从 `feature.frame_width/height` 写磁盘 `wh` 数组；`load` 把 record `wh` 还原到 `FrameFeature.frame_width/height`（不再灌 metadata）；**删 `_extract_frame_wh`**。
+- offline [offline/segmenters/clean.py](../../app/services/inference/offline/segmenters/clean.py) `_frame_size`：读 `frame.frame_width/height`，缺失回退默认。
+
+## 边界 / 不动
+- 磁盘格式与老文件兼容，无数据迁移；无 `wh` 的更老记录 → `frame_width/height=None` → offline 默认兜底（行为不变）。该兜底非冗余：离线 segmenter 的可配置默认分辨率（`stage_factory` **params）与 wh-less 测试数据都走它。
+- online（6 维）与 offline（113+ 维）两条特征管线仍刻意分离，本次只统一分辨率来源为 `FrameFeature.frame_width/height`（消解上一篇 `frame_shape`/`frame_width` 名不一致）。
+
+## 测试
+- [tests/factories.py](../../tests/factories.py)：`make_frame_feature`/`make_frame_inference` + `frame_width`/`frame_height` 参数。
+- `test_offline_pipeline` 的分辨率往返：断言 `FrameFeature.frame_width/height` 而非 `metadata.frame_width/height`。
+- `test_pool_ts_anchor`：断言 pool 从 `(8,8,3)` 帧盖章 `(fi.frame_width, fi.frame_height) == (8, 8)` 并透传到 FrameFeature。
+- `pytest tests/` **335 passed**。

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from app.domain.alarm import Alarm
-from app.domain.detection import Detection, FrameDetections
+from app.domain.detection import Detection, FrameDetections, FrameFeature
 from app.domain.frame import Frame
 from app.services.client.queues import ClientQueues
 from app.services.inference.models import FrameInference
@@ -55,6 +55,19 @@ def make_frame_detections(
         timestamp=ts,
         **over,
     )
+
+
+def make_frame_feature(
+    *, ts: float = 1.0, by_source: Optional[Dict[str, FrameDetections]] = None,
+    source: str = "bubble", n: int = 1, class_name: str = "bubble",
+    metadata: Optional[Dict] = None,
+) -> FrameFeature:
+    """一帧多流对齐记录（特征层输入）。by_source 缺省单流 {source: <n 个检测>}。"""
+    if by_source is None:
+        by_source = {
+            source: make_frame_detections(n=n, class_name=class_name, ts=ts, metadata=metadata)
+        }
+    return FrameFeature(ts=ts, by_source=by_source)
 
 
 def make_frame(*, ts: float = 1.0, shape=(4, 4, 3)) -> Frame:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -61,13 +61,17 @@ def make_frame_feature(
     *, ts: float = 1.0, by_source: Optional[Dict[str, FrameDetections]] = None,
     source: str = "bubble", n: int = 1, class_name: str = "bubble",
     metadata: Optional[Dict] = None,
+    frame_width: Optional[int] = None, frame_height: Optional[int] = None,
 ) -> FrameFeature:
-    """一帧多流对齐记录（特征层输入）。by_source 缺省单流 {source: <n 个检测>}。"""
+    """一帧多流对齐记录（特征层输入）。by_source 缺省单流 {source: <n 个检测>}。
+
+    frame_width/frame_height 为帧级分辨率，缺省 None（消费方走默认兜底）。
+    """
     if by_source is None:
         by_source = {
             source: make_frame_detections(n=n, class_name=class_name, ts=ts, metadata=metadata)
         }
-    return FrameFeature(ts=ts, by_source=by_source)
+    return FrameFeature(ts=ts, by_source=by_source, frame_width=frame_width, frame_height=frame_height)
 
 
 def make_frame(*, ts: float = 1.0, shape=(4, 4, 3)) -> Frame:
@@ -94,11 +98,13 @@ def make_frame_inference(
     *, cq: Optional[ClientQueues] = None, task_id: Optional[int] = None,
     stage: Optional[str] = None, ts: float = 1.0,
     detectors: Optional[Dict[str, FrameDetections]] = None,
+    frame_width: Optional[int] = None, frame_height: Optional[int] = None,
 ) -> FrameInference:
     """推理结果消息。task_id/stage 缺省从 cq 派生（无 cq 时回退 1/"3"）。
 
     detectors 缺省为单流 {"bubble": <1 检测>}；写回句柄 fence 类测试传 cq=<句柄>，
     离线/直连 FeatureStore 类测试传 cq=None 并显式给 detectors。
+    frame_width/frame_height 为帧级分辨率，缺省 None。
     """
     if detectors is None:
         detectors = {"bubble": make_frame_detections(ts=ts)}
@@ -108,6 +114,8 @@ def make_frame_inference(
         timestamp=ts,
         detections=detectors,
         cq=cq,
+        frame_width=frame_width,
+        frame_height=frame_height,
     )
 
 

--- a/tests/test_alarm_increment.py
+++ b/tests/test_alarm_increment.py
@@ -7,7 +7,7 @@
 
 from unittest.mock import patch
 
-from factories import make_alarm, make_bare_cq, make_cq, make_frame_detections
+from factories import make_alarm, make_bare_cq, make_cq, make_frame_detections, make_frame_feature
 
 
 def _cq_with_task():
@@ -114,7 +114,7 @@ def test_blocked_alarm_not_recorded():
 
 def test_slide_window_summary():
     cq = make_bare_cq()
-    cq.push_detection("bubble", make_frame_detections(n=1, class_name="bubble", ts=10.0))
+    cq.push_detection(make_frame_feature(source="bubble", n=1, class_name="bubble", ts=10.0))
     summary = cq.get_slide_window_summary()
     assert summary["bubble"]["active"] is True
     assert summary["bubble"]["hit_count"] == 1

--- a/tests/test_cq_immutable_run.py
+++ b/tests/test_cq_immutable_run.py
@@ -1,6 +1,6 @@
 """T1: CQ per-run 不可变 —— 身份构造注入、复用机器已删、换槽、存储 supersede。"""
 
-from factories import make_bare_cq, make_cq, make_frame_detections
+from factories import make_bare_cq, make_cq, make_frame_feature
 from app.services.client.manager import ClientManager
 from app.services.inference.feature.store import FeatureStore
 
@@ -17,7 +17,7 @@ def test_cq_identity_immutable_and_reuse_machinery_gone():
         assert not hasattr(cq, gone), f"{gone} 应已删除"
 
     # clear() 只释放 payload，不重置不可变身份
-    cq.push_detection("x", make_frame_detections(n=0, ts=1.0))
+    cq.push_detection(make_frame_feature(source="x", n=0, ts=1.0))
     cq.clear()
     assert cq.task_id == 7
     assert cq.step_id == 3

--- a/tests/test_cq_state_machine.py
+++ b/tests/test_cq_state_machine.py
@@ -1,14 +1,12 @@
 """T2: CQ 状态机 + 写门 + close() —— 迟到写入在写入时刻被拒。"""
 
-from types import SimpleNamespace
-
-from factories import make_alarm, make_cq, make_frame, make_frame_detections
+from factories import make_alarm, make_cq, make_frame, make_frame_feature
 from app.services.client.queues import RunState
 
 
 # 本地薄别名：保留原用例可读性，构造逻辑收敛在 factories。
 def _det():
-    return make_frame_detections(class_name="b")
+    return make_frame_feature(source="bubble", class_name="b")
 
 
 # --- 转换：幂等、单调 ---
@@ -39,9 +37,9 @@ def test_frame_and_result_writes_blocked_when_not_active():
     assert cq.append_ca_raw(make_frame()) is False
     cq.append_ca_processed(make_frame())
     assert cq.get_ca_processed_length() == 0
-    cq.push_detection("bubble", _det())
-    assert cq.get_slide_window("bubble") == []
-    cq.set_latest_inference(SimpleNamespace(detections={}, timestamp=1.0))
+    cq.push_detection(_det())
+    assert cq.get_slide_window() == []
+    cq.set_latest_inference(make_frame_feature())
     assert cq.get_latest_inference() is None
 
 
@@ -76,11 +74,11 @@ def test_clear_through_writes_allowed_when_not_active():
 
 def test_close_releases_payload_keeps_identity():
     cq = make_cq()
-    cq.push_detection("bubble", _det())
+    cq.push_detection(_det())
     cq.append_ca_raw(make_frame())
     cq.close()
     # payload 已释放
-    assert cq.get_slide_window("bubble") == []
+    assert cq.get_slide_window() == []
     assert len(cq.ca_raw) == 0
     assert cq.get_recent_alarms() == []
     assert cq.get_latest_inference() is None
@@ -103,5 +101,5 @@ def test_late_write_to_closed_cq_rejected():
     old = make_cq()
     old.close()                              # 模拟旧 run 已拆除
     assert old.append_ca_ready_with_throttle(make_frame()) is False
-    old.push_detection("bubble", _det())
-    assert old.get_slide_window("bubble") == []
+    old.push_detection(_det())
+    assert old.get_slide_window() == []

--- a/tests/test_feature_store_owner_fence.py
+++ b/tests/test_feature_store_owner_fence.py
@@ -7,14 +7,14 @@ owner 用对象引用（run 身份 = cq 对象），owner 不符即"迟到于 su
 
 import tempfile
 
-from factories import make_frame_detections, make_frame_inference
+from factories import make_frame_detections, make_frame_feature
 from app.services.inference.feature.store import FeatureStore
 
 
 def _result(ts: float, cls: str, n: int):
-    return make_frame_inference(
-        cq=None, task_id=1, stage="3", ts=ts,
-        detectors={"bubble": make_frame_detections(n=n, class_name=cls, ts=ts)},
+    return make_frame_feature(
+        ts=ts,
+        by_source={"bubble": make_frame_detections(n=n, class_name=cls, ts=ts)},
     )
 
 
@@ -23,8 +23,8 @@ def test_owner_match_lands():
     a = object()
     fs.open_fresh(7, 1, owner=a)
     fs.append(7, 1, _result(1.0, "bubble", 2), owner=a)
-    got = fs.load(7, 1, source="bubble")
-    assert len(got) == 1 and len(got[0].detections) == 2
+    frames = fs.load(7, 1)
+    assert len(frames) == 1 and len(frames[0].by_source["bubble"].detections) == 2
 
 
 def test_stale_owner_rejected_after_supersede():
@@ -43,18 +43,18 @@ def test_stale_owner_rejected_after_supersede():
     # B 的正常写 → 落
     fs.append(7, 1, _result(3.0, "bubble", 1), owner=b)
 
-    got = fs.load(7, 1, source="bubble")
+    frames = fs.load(7, 1)
     # 只见 B 的序列：A 起始帧被 open_fresh 截断、A 迟到帧被归属校验拒
-    assert len(got) == 1
-    assert got[0].timestamp == 3.0
-    assert len(got[0].detections) == 1
+    assert len(frames) == 1
+    assert frames[0].ts == 3.0
+    assert len(frames[0].by_source["bubble"].detections) == 1
 
 
 def test_owner_none_backward_compatible():
     """不调 open_fresh 时 _owner 恒空 → owner=None 放行（既有直连测试语义不变）。"""
     fs = FeatureStore(tempfile.mkdtemp(), batch_size=1)
     fs.append(7, 1, _result(1.0, "bubble", 2))  # owner 默认 None
-    assert len(fs.load(7, 1, source="bubble")) == 1
+    assert len(fs.load(7, 1)) == 1
 
 
 def test_close_clears_owner_by_identity():

--- a/tests/test_offline_pipeline.py
+++ b/tests/test_offline_pipeline.py
@@ -8,9 +8,9 @@ import math
 
 import pytest
 
-from factories import make_detection, make_frame_detections, make_frame_inference
+from factories import make_detection, make_frame_detections, make_frame_feature
 
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameDetections, FrameFeature
 from app.services.inference.config import InferenceConfig
 from app.services.inference.feature.store import FactLedger, FeatureStore
 from app.services.inference.models import EventFact, SegmentFact
@@ -25,12 +25,23 @@ _CLEAN_CLASS = "app.services.inference.offline.segmenters.clean.CleanSegmenter"
 
 # ============================ 存储引擎 ============================
 
-def _append_frame(store: FeatureStore, task_id, step_id, ts, detectors):
-    """经 FeatureStore.append 写一帧（detectors: name -> FrameDetections）。"""
-    store.append(task_id, step_id, make_frame_inference(cq=None, ts=ts, detectors=detectors))
+def _append_frame(store: FeatureStore, task_id, step_id, ts, detectors,
+                  frame_width=None, frame_height=None):
+    """经 FeatureStore.append 写一帧（detectors: name -> FrameDetections）。frame_width/height 为帧级分辨率。"""
+    store.append(task_id, step_id, make_frame_feature(
+        ts=ts, by_source=detectors, frame_width=frame_width, frame_height=frame_height))
 
 
-class TestLoadMany:
+def _frames(per_source):
+    """{src: [FrameDetections 按 ts]} → List[FrameFeature]（按 ts 对齐+升序），供直调 preprocess。"""
+    by_ts: dict = {}
+    for src, fds in per_source.items():
+        for fd in fds:
+            by_ts.setdefault(fd.timestamp, {})[src] = fd
+    return [FrameFeature(ts=ts, by_source=by_ts[ts]) for ts in sorted(by_ts)]
+
+
+class TestLoad:
     def test_single_scan_multi_source_and_empty_frames_kept(self, tmp_path):
         store = FeatureStore(tmp_path)
         # ts=1: 两源都有；ts=2: large 空帧(0 检测)、small 有；ts=3: 只有 large
@@ -45,22 +56,22 @@ class TestLoadMany:
         _append_frame(store, 7, 2, 3.0, {
             "clean_large": make_frame_detections(n=1, ts=3.0),
         })
-        out = store.load_many(7, 2, ["clean_large", "clean_small"])
-        # large 出现在 ts 1/2/3（含 2 的空帧）；small 出现在 1/2
-        assert [fd.timestamp for fd in out["clean_large"]] == [1.0, 2.0, 3.0]
-        assert [fd.timestamp for fd in out["clean_small"]] == [1.0, 2.0]
-        assert len(out["clean_large"][1].detections) == 0  # 空检测帧保留
+        frames = store.load(7, 2)
+        assert [ff.ts for ff in frames] == [1.0, 2.0, 3.0]  # 按 ts 升序
+        # by_source 键集 = 该帧含的 source（present-key）；空检测帧保留
+        assert set(frames[0].by_source) == {"clean_large", "clean_small"}
+        assert set(frames[1].by_source) == {"clean_large", "clean_small"}
+        assert set(frames[2].by_source) == {"clean_large"}   # ts=3 只有 large
+        assert len(frames[1].by_source["clean_large"].detections) == 0  # 空检测帧保留
 
-    def test_missing_file_returns_empty_lists(self, tmp_path):
-        out = FeatureStore(tmp_path).load_many(1, 1, ["a", "b"])
-        assert out == {"a": [], "b": []}
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert FeatureStore(tmp_path).load(1, 1) == []
 
     def test_sorted_by_ts(self, tmp_path):
         store = FeatureStore(tmp_path)
         for ts in (3.0, 1.0, 2.0):
             _append_frame(store, 1, 1, ts, {"a": make_frame_detections(n=1, ts=ts)})
-        out = store.load_many(1, 1, ["a"])
-        assert [fd.timestamp for fd in out["a"]] == [1.0, 2.0, 3.0]
+        assert [ff.ts for ff in store.load(1, 1)] == [1.0, 2.0, 3.0]
 
     def test_corrupt_line_skipped(self, tmp_path):
         store = FeatureStore(tmp_path)
@@ -70,23 +81,28 @@ class TestLoadMany:
         with path.open("a", encoding="utf-8") as f:
             f.write("{ not json\n")
         _append_frame(store, 1, 1, 2.0, {"a": make_frame_detections(n=1, ts=2.0)})
-        out = store.load_many(1, 1, ["a"])
-        assert [fd.timestamp for fd in out["a"]] == [1.0, 2.0]
+        assert [ff.ts for ff in store.load(1, 1)] == [1.0, 2.0]
 
-    def test_load_delegates_to_load_many(self, tmp_path):
+    def test_wh_round_trip_restores_frame_size(self, tmp_path):
+        """append 带帧级分辨率的帧 → load 还原到 FrameFeature.frame_width/height（不再灌 metadata）。"""
         store = FeatureStore(tmp_path)
-        _append_frame(store, 1, 1, 1.0, {"a": make_frame_detections(n=1, ts=1.0)})
-        assert len(store.load(1, 1, "a")) == 1
+        _append_frame(store, 1, 1, 1.0, {
+            "a": make_frame_detections(n=1, ts=1.0),
+        }, frame_width=640, frame_height=480)
+        ff = store.load(1, 1)[0]
+        assert (ff.frame_width, ff.frame_height) == (640, 480)
+        assert ff.by_source["a"].metadata == {}
+        assert len(ff.by_source["a"].detections) == 1
 
     def test_utf8_bom_tolerated(self, tmp_path):
-        """Windows 手写 features.jsonl 的 UTF-8 BOM 应能被 load_many 正常还原。"""
+        """Windows 手写 features.jsonl 的 UTF-8 BOM 应能被 load 正常还原。"""
         path = tmp_path / "1" / "1" / "features.jsonl"
         path.parent.mkdir(parents=True)
         row = {"ts": 1.0, "features": {"a": [{"bbox": [1, 2, 3, 4], "conf": 0.9, "cls_id": 0, "cls": "hand"}]}}
         path.write_text("﻿" + json.dumps(row, ensure_ascii=False) + "\n", encoding="utf-8")
-        out = FeatureStore(tmp_path).load_many(1, 1, ["a"])
-        assert [fd.timestamp for fd in out["a"]] == [1.0]
-        assert len(out["a"][0].detections) == 1
+        frames = FeatureStore(tmp_path).load(1, 1)
+        assert [ff.ts for ff in frames] == [1.0]
+        assert len(frames[0].by_source["a"].detections) == 1
 
 
 def _seg(source="p", label="x", start=0.0, end=1.0, producer=None):
@@ -223,7 +239,7 @@ class TestBrushRulesSegmenter:
             make_frame_detections(n=0, ts=3.0),   # idle → 断段
             make_frame_detections(n=1, ts=4.0),   # active（新段）
         ]}
-        segs = seg.segment(seg.preprocess(streams))
+        segs = seg.segment(seg.preprocess(_frames(streams)))
         assert [(s.start, s.end) for s in segs] == [(1.0, 2.0), (4.0, 4.0)]
         assert all(s.source == "p" for s in segs)
 
@@ -233,12 +249,12 @@ class TestBrushRulesSegmenter:
             make_frame_detections(n=1, ts=1.0),   # 单帧段，min_frames=2 丢弃
             make_frame_detections(n=0, ts=2.0),
         ]}
-        assert seg.segment(seg.preprocess(streams)) == []
+        assert seg.segment(seg.preprocess(_frames(streams))) == []
 
     def test_debug_result_none(self):
         """presence 型无逐帧语义：debug_result 恒 None（Runner 据此不落逐帧 JSON）。"""
         seg = BrushRulesSegmenter(name="p", subscribes=["a"])
-        seg.segment(seg.preprocess({"a": [make_frame_detections(n=1, ts=1.0)]}))
+        seg.segment(seg.preprocess(_frames({"a": [make_frame_detections(n=1, ts=1.0)]})))
         assert seg.debug_result() is None
 
 
@@ -266,7 +282,7 @@ class TestCleanSegmenter:
             "clean_large": [_clean_frame(t)["clean_large"] for t in (0.1, 0.2, 0.3, 0.4)],
             "clean_small": [_clean_frame(t)["clean_small"] for t in (0.1, 0.2, 0.3, 0.4)],
         }
-        mi = seg.preprocess(streams)
+        mi = seg.preprocess(_frames(streams))
         assert isinstance(mi, ModelInput)
         assert mi.frame_count == 4 and mi.feature_dim == 113  # v2: hand top-2 + top-1/impute/relations
         assert mi.feature_version == "clean_bbox_v2_top1_impute"
@@ -289,9 +305,10 @@ class TestCleanSegmenter:
         asformer = CleanASFormerSegmenter(name="a", subscribes=["clean_large", "clean_small"], fps=10.0)
         bigru = CleanBiGRUSegmenter(name="b", subscribes=["clean_large", "clean_small"], fps=10.0)
 
-        mstcn_input = mstcn.preprocess(streams)
-        asformer_input = asformer.preprocess(streams)
-        bigru_input = bigru.preprocess(streams)
+        frames = _frames(streams)
+        mstcn_input = mstcn.preprocess(frames)
+        asformer_input = asformer.preprocess(frames)
+        bigru_input = bigru.preprocess(frames)
 
         assert (mstcn.feature_method, mstcn_input.feature_dim, mstcn_input.feature_version) == (
             "v2", 113, "clean_bbox_v2_top1_impute",
@@ -312,7 +329,7 @@ class TestCleanSegmenter:
             "clean_small": [_clean_frame(t)["clean_small"] for t in (0.1, 0.2, 0.3)],
         }
         with pytest.raises(ValueError, match="model_path"):
-            seg.segment(seg.preprocess(streams))
+            seg.segment(seg.preprocess(_frames(streams)))
         assert seg.debug_result() is None
 
 
@@ -391,7 +408,7 @@ class TestOfflineRunner:
         """CleanSegmenter 不再规则降级；未配 model_path 时硬失败且不落结果。"""
         store = FeatureStore(tmp_path)
         for t in (0.1, 0.2, 0.3, 0.4):
-            store.append(1, 2, make_frame_inference(cq=None, ts=t, detectors=_clean_frame(t)))
+            store.append(1, 2, make_frame_feature(ts=t, by_source=_clean_frame(t)))
         store.flush(1, 2)
         offline = dict(_OFFLINE_OK, **{"class": _CLEAN_CLASS,
                                        "params": {"min_duration_s": 0.1, "fps": 10.0}})
@@ -411,8 +428,8 @@ class TestOfflineRunner:
         }}})
         store = FeatureStore(tmp_path)
         # MockDetector 纯透传：空检测帧 → 0 段，但链路走通
-        store.append(1, -1, make_frame_inference(cq=None, ts=1.0,
-                                                 detectors={"mock": make_frame_detections(n=0, ts=1.0)}))
+        store.append(1, -1, make_frame_feature(ts=1.0,
+                                               by_source={"mock": make_frame_detections(n=0, ts=1.0)}))
         store.flush(1, -1)
         res = OfflineRunner(base_dir=tmp_path, config=cfg).run(OfflineRunSpec(task_id=1, step_id=-1))
         assert res.status == "completed"
@@ -421,8 +438,8 @@ class TestOfflineRunner:
 
 
 class BoomSegmenter(OfflineSegmenter):
-    def preprocess(self, streams):
-        return streams
+    def preprocess(self, frames):
+        return frames
 
     def segment(self, model_input):
         raise RuntimeError("boom")
@@ -431,8 +448,8 @@ class BoomSegmenter(OfflineSegmenter):
 class MarkerSegmenter(OfflineSegmenter):
     """验证 preprocess 预留层被 runner 调用：preprocess 打标，segment 据标产段。"""
 
-    def preprocess(self, streams):
-        return {"marked": True, "streams": streams}
+    def preprocess(self, frames):
+        return {"marked": True, "frames": frames}
 
     def segment(self, model_input):
         assert model_input.get("marked") is True  # runner 确实先调了 preprocess

--- a/tests/test_offline_reservation.py
+++ b/tests/test_offline_reservation.py
@@ -9,16 +9,16 @@ FeatureStore（特征）与 FactLedger（事实，offline 预置）按 (task_id,
 
 import tempfile
 
-from factories import make_frame_detections, make_frame_inference
+from factories import make_frame_detections, make_frame_feature
 from app.services.inference.models import EventFact, SegmentFact
 from app.services.inference.feature.store import FactLedger, FeatureStore
 
 
 def _make_result(ts: float, bubble_n: int, bending_n: int):
-    # 直连 FeatureStore.append，只读 .detections/.timestamp，不碰 .cq → cq=None
-    return make_frame_inference(
-        cq=None, task_id=1, stage="LEAK", ts=ts,
-        detectors={
+    # 直连 FeatureStore.append，帧级 FrameFeature（无 cq）
+    return make_frame_feature(
+        ts=ts,
+        by_source={
             "bubble": make_frame_detections(n=bubble_n, class_name="bubble", ts=ts),
             "bending": make_frame_detections(n=bending_n, class_name="bent", ts=ts),
         },
@@ -34,12 +34,13 @@ def test_feature_store_load_roundtrip():
     fs.append(7, 1, _make_result(3.0, bubble_n=3, bending_n=0))
     fs.close(7, 1)
 
-    bubble_seq = fs.load(7, 1, source="bubble")
-    assert [o.timestamp for o in bubble_seq] == [1.0, 2.0, 3.0]
+    frames = fs.load(7, 1)
+    assert [ff.ts for ff in frames] == [1.0, 2.0, 3.0]
+    bubble_seq = [ff.by_source["bubble"] for ff in frames]
     assert [len(o.detections) for o in bubble_seq] == [2, 0, 3]
     assert bubble_seq[0].detections[0].class_name == "bubble"
 
-    bending_seq = fs.load(7, 1, source="bending")
+    bending_seq = [ff.by_source["bending"] for ff in frames]
     assert [len(o.detections) for o in bending_seq] == [0, 1, 0]
 
 
@@ -52,13 +53,13 @@ def test_feature_store_step_isolation():
     fs.close(7, 1)
     fs.close(7, 2)
 
-    assert [len(o.detections) for o in fs.load(7, 1, source="bubble")] == [2]
-    assert [len(o.detections) for o in fs.load(7, 2, source="bubble")] == [5]
+    assert [len(ff.by_source["bubble"].detections) for ff in fs.load(7, 1)] == [2]
+    assert [len(ff.by_source["bubble"].detections) for ff in fs.load(7, 2)] == [5]
 
 
 def test_feature_store_load_missing_returns_empty():
     fs = FeatureStore(tempfile.mkdtemp())
-    assert fs.load(999, 1, source="bubble") == []
+    assert fs.load(999, 1) == []
 
 
 def test_fact_ledger_mixed_roundtrip():

--- a/tests/test_operator_framework.py
+++ b/tests/test_operator_framework.py
@@ -1,12 +1,11 @@
-"""流处理框架新增能力测试：subscribes 注入 / 感受野 _clip / 多流 zip / 缓冲按感受野 / per-operator 隔离。"""
+"""流处理框架能力测试：subscribes 注入 / 感受野 _clip / 帧窗投影 / 缓冲按感受野 / per-operator 隔离。"""
 
-import threading
-from typing import Dict, List, Tuple
+from typing import List
 from unittest.mock import MagicMock
 
 import pytest
 
-from factories import make_bare_cq, make_frame_detections
+from factories import make_bare_cq, make_frame_detections, make_frame_feature
 from app.services.inference.config import load_stage_config
 from app.domain.alarm import Alarm, AlarmType
 from app.services.inference.stage_factory import StageFactory
@@ -54,32 +53,37 @@ def test_factory_injects_subscribes_and_metric_keys():
 
 
 def test_clip_to_receptive_field():
-    win = [_out(t) for t in [0.0, 1.0, 2.0, 3.0, 4.0]]  # latest=4.0
+    win = [make_frame_feature(source="s", ts=t) for t in [0.0, 1.0, 2.0, 3.0, 4.0]]  # latest=4.0
     op_small = _NoopOperator(name="a", subscribes=["s"], window_seconds=2.0)
     op_big = _NoopOperator(name="b", subscribes=["s"], window_seconds=5.0)
     # 感受野 2s → 保留 ts>=2.0：2,3,4
-    assert [d.timestamp for d in op_small._clip(win)] == [2.0, 3.0, 4.0]
+    assert [f.ts for f in op_small._clip(win)] == [2.0, 3.0, 4.0]
     # 感受野 5s → 全保留
-    assert [d.timestamp for d in op_big._clip(win)] == [0.0, 1.0, 2.0, 3.0, 4.0]
+    assert [f.ts for f in op_big._clip(win)] == [0.0, 1.0, 2.0, 3.0, 4.0]
 
 
-# ========== 多流按 ts zip（inner-join）==========
+# ========== 帧窗投影（单订阅取自身流，多流已在写回口对齐）==========
 
 
-def test_zip_by_ts_inner_join():
-    op = _NoopOperator(name="m", subscribes=["a", "b"], window_seconds=10.0)
-    windows = {
-        "a": [_out(1.0), _out(2.0), _out(3.0)],
-        "b": [_out(2.0), _out(3.0), _out(4.0)],  # 缺 1.0、多 4.0
-    }
-    aligned = op._zip_by_ts(windows)
-    assert [fr.ts for fr in aligned] == [2.0, 3.0]  # 仅共有 ts
-    assert set(aligned[0].by_source.keys()) == {"a", "b"}
+def test_primary_window_projects_subscribed_source():
+    op = _NoopOperator(name="p", subscribes=["a"], window_seconds=10.0)
+    # 每帧 by_source 同时含 a/b（写回口已对齐）；primary_window 只投影订阅的 a
+    win = [
+        make_frame_feature(ts=t, by_source={"a": _out(t), "b": _out(t, n=2)})
+        for t in [1.0, 2.0, 3.0]
+    ]
+    projected = op.primary_window(win)
+    assert [fd.timestamp for fd in projected] == [1.0, 2.0, 3.0]
+    assert all(fd.detections[0].class_name == "x" for fd in projected)
 
 
-def test_zip_by_ts_empty_when_a_stream_missing():
-    op = _NoopOperator(name="m", subscribes=["a", "b"], window_seconds=10.0)
-    assert op._zip_by_ts({"a": [_out(1.0)], "b": []}) == []
+def test_primary_window_skips_frames_missing_source():
+    op = _NoopOperator(name="p", subscribes=["a"], window_seconds=10.0)
+    win = [
+        make_frame_feature(ts=1.0, by_source={"a": _out(1.0)}),
+        make_frame_feature(ts=2.0, by_source={"b": _out(2.0)}),  # 无 a → 跳过
+    ]
+    assert [fd.timestamp for fd in op.primary_window(win)] == [1.0]
 
 
 # ========== subscribes 必填 ==========
@@ -96,20 +100,20 @@ def test_subscribes_required():
 def test_stream_buffer_floor_10s():
     cq = make_bare_cq()
     for t in [0.0, 5.0, 10.0, 15.0, 20.0]:
-        cq.push_detection("x", _out(t))
+        cq.push_detection(make_frame_feature(source="x", ts=t))
     # 未配感受野 → 底线 10s：cutoff=20-10=10 → 保留 10,15,20
-    win = cq.get_slide_window("x")
-    assert [d.timestamp for d in win] == [10.0, 15.0, 20.0]
+    win = cq.get_slide_window()
+    assert [f.ts for f in win] == [10.0, 15.0, 20.0]
 
 
 def test_stream_buffer_extends_with_receptive_field():
     cq = make_bare_cq()
     cq.set_stream_windows({"x": 30.0})  # 感受野 30s > 底线
     for t in [0.0, 5.0, 10.0, 15.0, 20.0]:
-        cq.push_detection("x", _out(t))
+        cq.push_detection(make_frame_feature(source="x", ts=t))
     # retain=max(10,30)=30：cutoff=20-30=-10 → 全保留
-    win = cq.get_slide_window("x")
-    assert [d.timestamp for d in win] == [0.0, 5.0, 10.0, 15.0, 20.0]
+    win = cq.get_slide_window()
+    assert [f.ts for f in win] == [0.0, 5.0, 10.0, 15.0, 20.0]
 
 
 # ========== per-operator 异常隔离 ==========
@@ -135,7 +139,7 @@ def test_per_operator_isolation():
     from app.services.inference.temporal.actor import ClientTemporalActor
 
     cq = MagicMock()
-    cq.get_slide_window.return_value = [_out(1.0)]
+    cq.get_slide_window.return_value = [make_frame_feature(source="s", ts=1.0)]
     captured: List[Alarm] = []
 
     bad = _BadOperator(name="bad", subscribes=["s"], window_seconds=3.0)

--- a/tests/test_pool_ts_anchor.py
+++ b/tests/test_pool_ts_anchor.py
@@ -1,22 +1,19 @@
 """守卫：多 detector 聚合后，同帧各流 FrameDetections.timestamp 必须相等（= 帧捕获真值锚点）。
 
-背景：detector 曾在推理时各自 time.time() 生成 FrameDetections.timestamp，违反 Operator._zip_by_ts
-"同帧多流 ts 精确相等（来自同一 FrameInference.timestamp）"的对齐不变式——单流算子侥幸不受影响，
-但多流融合算子会因两流 ts 对不上而 inner-join 交集为空、整帧被丢。
+背景：detector 曾在推理时各自 time.time() 生成 FrameDetections.timestamp，破坏"同帧多流 ts 精确
+相等（来自同一 FrameInference.timestamp）"的不变式。写回口按 `FrameFeature(ts=res.timestamp,
+by_source=res.detections)` 物化整帧多流；帧窗算子用 FrameFeature.ts 裁窗、用投影出的
+FrameDetections.timestamp 推进游标，两者必须同源同值，否则内部对齐错乱。
 
 修复：帧捕获 ts 从 pool.infer_batch 一路穿到 detector，令每帧
 FrameDetections.timestamp == FrameInference.timestamp == Frame.timestamp。本用例锁死该不变式。
 """
 
-from typing import Dict, List, Tuple
-
 import numpy as np
 
-from app.domain.alarm import Alarm
-from app.domain.detection import FrameDetections
+from app.domain.detection import FrameFeature
 from app.services.inference.detection.pool import MultiModelWorkerPool
 from app.services.inference.models import DetectionTask
-from app.services.inference.temporal.operator import Operator
 from app.services.inference.workflows.mock import MockDetector
 
 from factories import make_cq
@@ -33,16 +30,6 @@ def _task(ts: float, cq) -> DetectionTask:
         task_id=cq.task_id, stage=cq.stage, timestamp=ts,
         frame=np.zeros((8, 8, 3), dtype=np.uint8), cq=cq,
     )
-
-
-class _TwoStreamOperator(Operator):
-    """订阅两条流的最小算子，仅用来驱动 _zip_by_ts。"""
-
-    def analyze(self, windows: Dict[str, List[FrameDetections]]) -> None:  # pragma: no cover
-        pass
-
-    def judge(self) -> Tuple[List[str], List[Alarm]]:  # pragma: no cover
-        return [], []
 
 
 def test_multi_detector_same_frame_shares_capture_ts():
@@ -65,8 +52,8 @@ def test_multi_detector_same_frame_shares_capture_ts():
         assert fd.timestamp == ts, f"{name} 流 ts={fd.timestamp} != 锚点 {ts}"
 
 
-def test_zip_by_ts_aligns_multi_stream_after_fix():
-    """两流经 pool 后，_zip_by_ts inner-join 能对齐（不再因 ts 不等而漏帧）。"""
+def test_frame_feature_carries_all_streams_at_capture_ts():
+    """两流经 pool 后，写回口物化的 FrameFeature 携两流、ts = 帧捕获锚点（取代旧 _zip_by_ts 对齐）。"""
     pool = MultiModelWorkerPool(
         stage="1",
         models=[_mock_detector("streamA"), _mock_detector("streamB")],
@@ -76,10 +63,8 @@ def test_zip_by_ts_aligns_multi_stream_after_fix():
     ts = 77.0
     fi = pool.infer_batch([_task(ts, cq)])[0]
 
-    op = _TwoStreamOperator(name="fuse", subscribes=["streamA", "streamB"], window_seconds=10.0)
-    windows = {name: [fd] for name, fd in fi.detections.items()}
-    aligned = op._zip_by_ts(windows)
-
-    assert len(aligned) == 1, "多流同帧应对齐出一帧；若为空说明 ts 不等的回归"
-    assert aligned[0].ts == ts
-    assert set(aligned[0].by_source) == {"streamA", "streamB"}
+    # 写回口构造：FrameFeature(ts=res.timestamp, by_source=res.detections)——多流天然对齐同帧。
+    feat = FrameFeature(ts=fi.timestamp, by_source=fi.detections)
+    assert feat.ts == ts
+    assert set(feat.by_source) == {"streamA", "streamB"}
+    assert all(fd.timestamp == ts for fd in feat.by_source.values())

--- a/tests/test_pool_ts_anchor.py
+++ b/tests/test_pool_ts_anchor.py
@@ -63,8 +63,15 @@ def test_frame_feature_carries_all_streams_at_capture_ts():
     ts = 77.0
     fi = pool.infer_batch([_task(ts, cq)])[0]
 
-    # 写回口构造：FrameFeature(ts=res.timestamp, by_source=res.detections)——多流天然对齐同帧。
-    feat = FrameFeature(ts=fi.timestamp, by_source=fi.detections)
+    # pool 从原始帧 (8,8,3) 盖章帧级分辨率 frame_width/height
+    assert (fi.frame_width, fi.frame_height) == (8, 8)
+
+    # 写回口构造：FrameFeature(ts, by_source, frame_width, frame_height)——多流天然对齐同帧。
+    feat = FrameFeature(
+        ts=fi.timestamp, by_source=fi.detections,
+        frame_width=fi.frame_width, frame_height=fi.frame_height,
+    )
     assert feat.ts == ts
+    assert (feat.frame_width, feat.frame_height) == (8, 8)
     assert set(feat.by_source) == {"streamA", "streamB"}
     assert all(fd.timestamp == ts for fd in feat.by_source.values())

--- a/tests/test_temporal_debounce.py
+++ b/tests/test_temporal_debounce.py
@@ -1,7 +1,7 @@
 """测试流算子 Operator 的边沿触发（去抖）机制 —— analyze 推进状态 / judge 出告警，共享 _sm
 
 验证合并后状态机行为与合并前一致：
-- operator.analyze(windows) 消费订阅流、推进共享 _sm（测量 + 决策同一份）
+- operator.analyze(windows) 消费帧窗（List[FrameFeature]，多流已对齐）、推进共享 _sm
 - operator.judge() 做边沿触发判定
   - rising edge: 条件首次成立 → 产出 1 条 AlarmInfo
   - sustained: 条件持续成立 → 不再产出
@@ -13,30 +13,27 @@ import time
 
 import pytest
 
-from factories import make_frame_detections
+from factories import make_frame_detections, make_frame_feature
 from app.domain.alarm import AlarmType
-from app.domain.detection import FrameDetections  # 仅用于类型注解
+from app.domain.detection import FrameFeature  # 仅用于类型注解
 
 
 # ========== Fixtures ==========
 
 
-def make_detection_output(n_detections: int = 0, class_name: str = "bubble"):
-    """构造 FrameDetections，指定检测数量（时间戳由 make_window 覆写）"""
-    return make_frame_detections(n=n_detections, class_name=class_name)
-
-
-def make_window(pattern: list[int], class_name: str = "bubble") -> list[FrameDetections]:
-    """按模式构造滑动窗口
+def make_window(pattern: list[int], class_name: str = "bubble",
+                source: str = "bubble") -> list[FrameFeature]:
+    """按模式构造帧窗（List[FrameFeature]，单流已对齐）
 
     pattern: e.g. [0, 0, 1, 1, 1] — 每个值表示该帧的检测数量
+    每帧 FrameFeature.ts 与内层 FrameDetections.timestamp 对齐同值。
     """
     base_ts = time.time() - len(pattern) * 0.1
     window = []
     for i, count in enumerate(pattern):
-        output = make_detection_output(count, class_name)
-        output.timestamp = base_ts + i * 0.1
-        window.append(output)
+        ts = base_ts + i * 0.1
+        fd = make_frame_detections(n=count, class_name=class_name, ts=ts)
+        window.append(make_frame_feature(ts=ts, by_source={source: fd}))
     return window
 
 
@@ -54,7 +51,7 @@ class TestBubbleEdgeTrigger:
 
     def test_no_alarm_below_threshold(self, op):
         """出生率低于阈值 → 无事件、无告警"""
-        op.analyze({"bubble": make_window([0, 0, 0])})
+        op.analyze(make_window([0, 0, 0]))
         events, alarms = op.judge()
         assert events == []
         assert alarms == []
@@ -62,7 +59,7 @@ class TestBubbleEdgeTrigger:
 
     def test_rising_edge_triggers_alarm(self, op):
         """首次超过阈值 → 产出事件 + 告警，alarming 置 True"""
-        op.analyze({"bubble": make_window([5, 5, 5])})
+        op.analyze(make_window([5, 5, 5]))
         events, alarms = op.judge()
         assert len(alarms) == 1
         assert alarms[0].alarm_type == AlarmType.PROCESS_VIOLATION
@@ -70,35 +67,35 @@ class TestBubbleEdgeTrigger:
 
     def test_sustained_no_repeat_alarm(self, op):
         """条件持续成立 → 有事件但无重复告警"""
-        op.analyze({"bubble": make_window([5, 5, 5])})
+        op.analyze(make_window([5, 5, 5]))
         _, alarms1 = op.judge()
         assert len(alarms1) == 1
 
-        op.analyze({"bubble": make_window([5, 5, 5, 5])})
+        op.analyze(make_window([5, 5, 5, 5]))
         _, alarms2 = op.judge()
         assert alarms2 == []
 
-        op.analyze({"bubble": make_window([5, 5, 5, 5, 5])})
+        op.analyze(make_window([5, 5, 5, 5, 5]))
         _, alarms3 = op.judge()
         assert alarms3 == []
 
     def test_falling_edge_resets(self, op):
         """条件消失 → alarming 复位为 False"""
-        op.analyze({"bubble": make_window([5, 5, 5])})
+        op.analyze(make_window([5, 5, 5]))
         op.judge()
         assert op._sm["alarming"] is True
 
         # 清空测量历史 + 重置游标，让下一次 birth_rate 归零
         op._sm["new_count_history"] = []
         op._sm["last_ts"] = 0.0
-        op.analyze({"bubble": make_window([0, 0, 0])})
+        op.analyze(make_window([0, 0, 0]))
         events, alarms = op.judge()
         assert alarms == []
         assert op._sm["alarming"] is False
 
     def test_empty_window(self, op):
         """空窗口 → analyze 无副作用，judge 安全返回空"""
-        op.analyze({"bubble": []})
+        op.analyze([])
         events, alarms = op.judge()
         assert events == []
         assert alarms == []
@@ -116,33 +113,33 @@ class TestBendingDebounce:
 
         return BendingOperator(debounce_frames=3, required_bend_actions=4)
 
-    def _make_bending_window(self, flags: list[bool]) -> list[FrameDetections]:
-        """构造弯折窗口，flags 中 True 表示该帧有 bent 检测"""
+    def _make_bending_window(self, flags: list[bool]) -> list[FrameFeature]:
+        """构造弯折帧窗，flags 中 True 表示该帧有 bent 检测（source="bending"）"""
         base_ts = time.time() - len(flags) * 0.1
         window = []
         for i, has_bending in enumerate(flags):
+            ts = base_ts + i * 0.1
             n = 1 if has_bending else 0
-            output = make_detection_output(n, class_name="bent")
-            output.timestamp = base_ts + i * 0.1
-            window.append(output)
+            fd = make_frame_detections(n=n, class_name="bent", ts=ts)
+            window.append(make_frame_feature(ts=ts, by_source={"bending": fd}))
         return window
 
     def test_debounce_increments_bend_actions(self, op):
         """连续 debounce_frames 帧 bent → bend_actions 增加（共享 _sm）"""
-        op.analyze({"bending": self._make_bending_window([True] * 5)})
+        op.analyze(self._make_bending_window([True] * 5))
         _, alarms = op.judge()
         assert op._sm["bend_actions"] >= 1
         assert alarms == []  # 实时阶段不产出告警
 
     def test_no_transition_below_debounce(self, op):
         """未满去抖帧数 → 不切换状态"""
-        op.analyze({"bending": self._make_bending_window([True, True])})  # 2 < 3
+        op.analyze(self._make_bending_window([True, True]))  # 2 < 3
         assert op._sm["state"] == "STRAIGHT"
         assert op._sm["bend_actions"] == 0
 
     def test_finalize_alarm_when_insufficient(self, op):
         """终态 bend_actions < required → finalize() 产出 warning"""
-        op.analyze({"bending": self._make_bending_window([True] * 5 + [False] * 5)})
+        op.analyze(self._make_bending_window([True] * 5 + [False] * 5))
         op.judge()
         alarms = op.finalize()
         assert len(alarms) == 1
@@ -159,13 +156,14 @@ class TestBendingDebounce:
         """STRAIGHT→BENT→STRAIGHT 完整转换（共享 _sm）"""
         assert op._sm["state"] == "STRAIGHT"
 
-        op.analyze({"bending": self._make_bending_window([True] * 3)})
+        op.analyze(self._make_bending_window([True] * 3))
         assert op._sm["state"] == "BENT"
 
         w2 = self._make_bending_window([False] * 3)
         for item in w2:
-            item.timestamp += 0.5  # 确保时间戳在游标之后
-        op.analyze({"bending": w2})
+            item.ts += 0.5  # 确保时间戳在游标之后
+            item.by_source["bending"].timestamp += 0.5
+        op.analyze(w2)
         assert op._sm["state"] == "STRAIGHT"
 
 

--- a/tests/test_writeback_handle_fence.py
+++ b/tests/test_writeback_handle_fence.py
@@ -20,8 +20,8 @@ class _SpyFeatureStore:
     def __init__(self):
         self.appended = []
 
-    def append(self, task_id, step_id, res, owner=None):
-        self.appended.append((task_id, step_id, res))
+    def append(self, task_id, step_id, feature, owner=None):
+        self.appended.append((task_id, step_id, feature))
 
 
 def _bare_service(feature_store) -> ModelWorkerService:
@@ -45,7 +45,9 @@ def test_active_run_write_back_lands():
 
     assert cq.get_latest_inference().by_source is res.detections  # 快照 = 物化 FrameFeature
     assert cq.get_slide_window()  # 检测入滑窗
-    assert fs.appended == [(1, 3, res)]  # 特征落盘键 = (task_id, step_id)
+    # 特征落盘键 = (task_id, step_id)；落的是帧级 FrameFeature（by_source 即 res.detections）
+    assert [a[:2] for a in fs.appended] == [(1, 3)]
+    assert fs.appended[0][2].by_source is res.detections
 
 
 def test_draining_run_write_back_blocked_and_counted():
@@ -91,4 +93,5 @@ def test_stale_and_active_in_same_batch_isolated():
 
     assert cq_stale.get_latest_inference() is None
     assert cq_active.get_latest_inference().by_source is res_active.detections
-    assert fs.appended == [(11, 3, res_active)]  # 仅 active 落盘
+    assert [a[:2] for a in fs.appended] == [(11, 3)]  # 仅 active 落盘
+    assert fs.appended[0][2].by_source is res_active.detections

--- a/tests/test_writeback_handle_fence.py
+++ b/tests/test_writeback_handle_fence.py
@@ -43,8 +43,8 @@ def test_active_run_write_back_lands():
     res = _result(cq)
     svc._write_back_results([res])
 
-    assert cq.get_latest_inference() is res
-    assert cq.get_slide_window("bubble")  # 检测入滑窗
+    assert cq.get_latest_inference().by_source is res.detections  # 快照 = 物化 FrameFeature
+    assert cq.get_slide_window()  # 检测入滑窗
     assert fs.appended == [(1, 3, res)]  # 特征落盘键 = (task_id, step_id)
 
 
@@ -58,7 +58,7 @@ def test_draining_run_write_back_blocked_and_counted():
     svc._write_back_results([_result(cq)])
 
     assert cq.get_latest_inference() is None  # 快照未落
-    assert cq.get_slide_window("bubble") == []  # 滑窗未落
+    assert cq.get_slide_window() == []  # 滑窗未落
     assert fs.appended == []  # 特征这条外部腿也被挡
     assert _stale_drops() - before == 1.0
 
@@ -90,5 +90,5 @@ def test_stale_and_active_in_same_batch_isolated():
     svc._write_back_results([res_stale, res_active])
 
     assert cq_stale.get_latest_inference() is None
-    assert cq_active.get_latest_inference() is res_active
+    assert cq_active.get_latest_inference().by_source is res_active.detections
     assert fs.appended == [(11, 3, res_active)]  # 仅 active 落盘


### PR DESCRIPTION
- 使用统一数据结构FrameFeature，存储单帧检测出的特征，供下游实时和离线链路消费
- 落盘存储jsonl与内存模型FrameFeature解耦，feature层双向映射来处理转换关系
- 各个算子现在并发读一个滑动窗口缓存特征，而非原本的fan-out策略
- transform_feature直接合并到preprocess里实现
- 部分函数改为直接内联
- FeatureVectorizer降级为工具函数