### PR TITLE
Refact/fps settings

### DIFF
--- a/.claude/skills/temporal-review/SKILL.md
+++ b/.claude/skills/temporal-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temporal-review
-description: "Review a temporal analyzer (时序分析模型算子) as it's onboarded into the inference chain — a GRU/Transformer/sequence-model Operator that turns detection windows into actions/states. Use when asked to: review 时序分析器/时序模型/GRU/Transformer 算子接入、review 时序推理代码、时序 Operator review、审查特征适配器/feature adapter、review temporal analyzer/operator. Checklist is severity-ranked: silent-wrong feature bugs first, then crashes, then lifecycle/causality, then style."
+description: "Review a temporal analyzer (时序分析模型算子) as it's onboarded into the inference chain — a GRU/Transformer/sequence-model Operator that turns detection windows into actions/states. Use when asked to: review 时序分析器/时序模型/GRU/Transformer 算子接入、review 时序推理代码、时序 Operator review、审查特征适配器/feature adapter、审查入模帧率/重采样/train-serve skew、review temporal analyzer/operator. Checklist is severity-ranked: silent-wrong feature bugs first, then crashes, then lifecycle/causality, then style."
 ---
 
 # 时序分析器接入 Review
@@ -19,6 +19,14 @@ description: "Review a temporal analyzer (时序分析模型算子) as it's onbo
 - **归一化裁剪**：docstring 常写"归一化到 [0,1]"，但代码有 `clamp` 吗？越界框/坐标系不匹配会喂负值或超界。
 - **分辨率来源**：除的是帧自带 `metadata["frame_shape"]`（[detector.py:151](../../../app/services/inference/detection/detector.py)）还是全局死配置 `get_client_config().frame.resize_*`（[config.py:21](../../../app/services/client/config.py)）？后者与真正定尺寸的 decoder ffmpeg `scale`（[decoder.py:86](../../../app/services/stream/decoder.py)）靠默认值巧合对齐，改一边忘同步即整体偏移且不报错。**适配器应是 `(detections, shape) → tensor` 纯函数，别读全局态。**
 
+## 🔴 入模时间密度 — train/serve fps skew（shape-check 抓不到的静默错）
+
+模型按**训练 fps 的时间密度**学时序；实时检测采样率 ≠ 训练 fps 时，不重采样就是喂错密度 —— 不抛异常、只是动作错，模型背锅。
+
+- **为何 shape-check 漏判**：fps 只改序列长度 T（变长轴），不改特征维 F。换个 fps 重训的权重加载时 shape/key 全过、密度已错 —— 这是词表数量类契约（能被 shape 抓）之外、**唯一抓不到的那类契约**。
+- **必须有显式重采样层**：入模前按帧 `ts` 把窗口重采样到模型契约帧率（见 [operator.py](../../../app/services/inference/temporal/operator.py) `_resample_by_ts`）；检测密度 ⟂ 模型节奏，中间隔一层，别把检测采样率焊死成模型输入率。
+- **`model_input_fps` 必填 + 加载期校验**：漏配**即崩**（yaml 缺 key → 构造缺参 TypeError；非正值 → `__init__` ValueError），别缺省 `None` + warning 放行 —— warning 会被无视、skew 静默复活。`window_seconds` 与 fps 共定 T，一并按**时间密度契约**看待，不是自由旋钮。
+
 ## 🟠 会抛异常
 
 - **bbox 硬解构** `x1,y1,x2,y2 = bbox`：`Detection.bbox` 契约变（mask/空框）即 `ValueError`。
@@ -29,7 +37,7 @@ description: "Review a temporal analyzer (时序分析模型算子) as it's onbo
 - **状态全在 `_sm`**：有无逸出成员（`history_frames` 类跨 tick 累加器）？破坏单 `_sm` 不变式。
 - **别重复造窗**：`analyze` 收到的 windows 已被 `_zip_by_ts`/`_clip` 按 `window_seconds` 裁到感受野；算子自己再攒一层历史 = 冗余 + 窗口随 tick 漂移。直接喂整窗。
 - **游标防重**：`last_ts` 跳过已推理帧，否则重叠滑窗重复前向。
-- **因果性（硬门）**：实时链路模型必须因果 —— 单向 GRU / causal mask。双向、或需未来帧才判定（MS-TCN 类）**不能进 1Hz 实时 tick**，走离线链路。感受域 ≥ 窗口；不足加显式 warm-up guard（帧数 < 阈值不推理）。
+- **因果性（硬门）**：实时链路模型必须因果 —— 单向 GRU / causal mask。双向、或需未来帧才判定（MS-TCN 类）**不能进 1Hz 实时 tick**，走离线链路。感受域 ≥ 窗口；不足加显式 warm-up guard（帧数 < 阈值不推理）。**确认 checkpoint 出自因果 pipeline**（训练仓 `sliding_window_temporal`），别把离线双向那版（`full_sequence_temporal` / BiGRU）拿来在线读 `logits[-1]` —— 最后一步后向上下文为零 = 静默误分类，且 jit blob 看不出它是否双向，得回训练仓核对产物来源。
 - **推理 seam**：惰性加载（双检锁）+ `model.eval()` + `torch.no_grad()`；torch/模型 import 下沉、模块顶层不引 torch（同 [detector.py](../../../app/services/inference/detection/detector.py) 把 ultralytics 延迟到加载处）；权重缺失显式报错。
 
 ## ⚪ 契约 / 放置 / 风格
@@ -45,8 +53,9 @@ description: "Review a temporal analyzer (时序分析模型算子) as it's onbo
 
 判据一句：**能自由调的才配；必须与另一产物严格一致的不配（随产物走）。** 用"配错了会怎样"分流：
 
-- 配错后**行为变、不崩、可调**（`subscribes`/`realtime`/`window_seconds`/`min_frames`/`model_path`）→ 真配置，留 YAML。
-- 配错后 **加载即 shape/key mismatch**（`hidden`/`num_layers`，以及 `objects`/`actions` 的**数量**——它们定 `input_dim=count*4` 与 `num_classes`）→ 这不是配置，是"必须逐位等于产物的契约副本"。放 YAML 只把单一真源劈成"权重+YAML"两处、制造漂移（换个重训权重就得记着同步改），失去配置驱动的意义、流程反更繁琐。label 字符串是词表里唯一"软"的（仅 overlay 显示），也随产物走。
+- 配错后**行为变、不崩、可调**（`subscribes`/`realtime`/`min_frames`/`model_path`）→ 真配置，留 YAML。
+- 配错后 **加载即 shape/key mismatch**（`hidden`/`num_layers`，以及 `objects`/`actions` 的**数量**——它们定 `input_dim = count × 每物体特征数` 与 `num_classes`）→ 这不是配置，是"必须逐位等于产物的契约副本"。放 YAML 只把单一真源劈成"权重+YAML"两处、制造漂移（换个重训权重就得记着同步改），失去配置驱动的意义、流程反更繁琐。label 字符串是词表里唯一"软"的（仅 overlay 显示），也随产物走。
+- 配错后 **不崩、不 shape-mismatch、静默喂错时间密度**（`model_input_fps`，及改变帧数的 `window_seconds`）→ 最阴的一类：skew 温床，shape-check 天生漏判（fps 改 T 不改 F）。至少**必填 + 加载期校验**（见上方 🔴 train/serve skew）；理想随产物走（下方 sidecar），别在部署 YAML 手抄一个 fps 数字。
 
 **实现待商榷（列菜单，别钦定）**——共同点都是配置跟着权重、不进 YAML：
 
@@ -59,7 +68,8 @@ description: "Review a temporal analyzer (时序分析模型算子) as it's onbo
 
 > 诚实排序（此项目一 GRU、一仓一模型）：safetensors+config ≳ torch.save dict ≫ 现状（arch 抄进 YAML）。别上 registry/onnx——单模型属过度。安全性（safetensors / `weights_only=True`）是当代实践一环，值得一并考虑。
 
-⚠️ 产物格式是**跨仓契约**（时序模型一模型一仓库），schema 需与训练侧约定，别单方拍板。审 YAML 时数一下 `params`：模型架构/词表超参占了一大半，就是该下沉的信号。
+⚠️ 产物格式是**跨仓契约**（时序模型一模型一仓库），schema 需与训练侧约定，别单方拍板。审 YAML 时数一下 `params`：模型架构/词表超参 + **帧率/窗口密度**（`model_input_fps`/`window_seconds`）占了一大半，就是该下沉的信号。
+训练仓（Cleansight_models）本就成对维护 `external_checkpoints/<id>/<id>.yaml`，登记 feature version / tensor shape / 类别顺序 / normalization / 窗口 —— 交付时让后端读这份 sidecar，别在后端 yaml 手抄。注意：它的严格加载器查 param-key + tensor-shape，**恰好抓不到 fps**（fps 改 T 不改 shape），所以 fps 是最该随 sidecar、最不能手抄的一项。
 
 ## 上线门禁（缺一不合入）
 

--- a/.gitignore
+++ b/.gitignore
@@ -166,7 +166,11 @@ app/data/*.pt
 test/*.mp4
 
 .agents/
-.claude/
+# .claude 下只跟踪团队共享的 skills/（方法论资产，需版本化追加）；其余（settings*.json、
+# skills-disabled/、session 数据）都是本地态，继续忽略。用「忽略目录内容 + 放行 skills」
+# 模式：整目录忽略时 git 不下钻，skills/ 里的新增文件会被静默挡掉。
+.claude/*
+!.claude/skills/
 command.txt
 AGENTS.md
 # 第三方 MediaMTX 可执行文件(用 scripts/install_mediamtx.sh 下载,不进 git)

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -14,6 +14,10 @@ from app.services.stream import stream_service
 router = APIRouter(prefix="/ai", tags=["ai"])
 logger = logging.getLogger(__name__)
 
+# WS live view 传输带宽上限（帧/秒）：传输层保护常量，非管线 fps、不进部署配置。
+# 推帧主驱动是"新帧即推"（按 frame.timestamp 去重）；此上限仅兜住突发，源 ~inference_fps 下极少触发。
+_WS_MAX_SEND_FPS = 30
+
 
 @asynccontextmanager
 async def lifespan():
@@ -76,10 +80,11 @@ async def websocket_video_endpoint(websocket: WebSocket):
     await websocket.accept()
     logger.info(f"[WebSocket] 连接已建立: {label}, remote={websocket.client}")
 
-    # 帧率控制和去重
-    last_sent_timestamp = 0.0  # 上一帧的时间戳（来自帧本身）
+    # 推帧驱动 = "新帧即推"（下方按 frame.timestamp 去重，见 last_sent_timestamp 分支）。
+    last_sent_timestamp = 0.0  # 上一帧的时间戳（来自帧本身）——主驱动：仅新帧才推
     last_sent_time = 0.0  # 上一次发送的系统时间
-    frame_interval = 1.0 / 30  # 30fps
+    # 传输带宽上限：本地传输层保护常量（非管线 fps、不进部署配置），兜住突发；源 ~inference_fps 下极少触发。
+    frame_interval = 1.0 / _WS_MAX_SEND_FPS
     frames_sent = 0
     last_log_time = time.time()
     streaming = False  # 是否处于推帧态：仅在"曾推帧 → 无 run"跳变时发一次 idle
@@ -131,7 +136,7 @@ async def websocket_video_endpoint(websocket: WebSocket):
                 await asyncio.sleep(0.01)
                 continue
 
-            # 帧率控制：确保发送间隔不小于 frame_interval
+            # 带宽上限：确保发送间隔不小于 frame_interval（传输节流，非管线 fps）
             current_time = time.time()
             if last_sent_time > 0:
                 time_since_last = current_time - last_sent_time

--- a/app/routers/traceback.py
+++ b/app/routers/traceback.py
@@ -287,23 +287,16 @@ def _build_vod_playlist(
     playlist_path = task_dir / f"{track}_playlist.m3u8"
     real_durations = _parse_existing_playlist(playlist_path)
 
-    try:
-        from app.services.persistence.config import get_persistence_config
-        default_dur = float(get_persistence_config().hls.segment_duration)
-    except Exception:
-        default_dur = 10.0
-
-    # VOD 时长唯一真值源 = 写入侧 playlist 的 EXTINF。不在 playlist 中的段视为
-    # 在途段（mp4v 已落但 transcode+append 未完成），过滤掉——避免回放出现
-    # 与 fmp4 tfdt 累计对不上的"估算"行，导致 hls.js MSE 缓冲洞。
+    # VOD 时长唯一真值源 = 写入侧 playlist 的 EXTINF（退化段的兜底也只在写入侧的 eff_fps
+    # 里，见 hls_strategy._DEGENERATE_FALLBACK_FPS）。此处只读回、不重新推导、无第二兜底。
+    # 不在 playlist 中的段视为在途段（mp4v 已落但 transcode+append 未完成），过滤掉——避免
+    # 回放出现与 fmp4 tfdt 累计对不上的"估算"行，导致 hls.js MSE 缓冲洞。
     segs = [s for s in segs if s.filename in real_durations]
     if not segs:
         raise HTTPException(status_code=404, detail="No playable segments yet")
 
-    target_duration = max(
-        int(round(max(real_durations.values(), default=default_dur))),
-        1,
-    )
+    # 上一步已保证 real_durations 非空（segs ⊆ real_durations 且非空），max() 无需 default。
+    target_duration = max(int(round(max(real_durations.values()))), 1)
 
     base_url = str(request.base_url).rstrip("/")
     init_token = MediaToken.default().sign(

--- a/app/services/client/config.py
+++ b/app/services/client/config.py
@@ -20,7 +20,8 @@ class FrameConfig:
 
     resize_width: int = 640  # Resize宽度
     resize_height: int = 480  # Resize高度
-    # 注意：inference_fps, ca_maxlen, ca_segment_len 从 app/settings.py 读取（单一真源）
+    # 注意：inference_fps 从 app/settings.py 读取（单一真源）；CA 缓存/段长以秒声明
+    # （ca_maxlen_seconds / ca_segment_seconds），帧数在 ca_maxlen/ca_segment_len 属性按 raw_fps 换算
 
 
 @dataclass
@@ -91,15 +92,15 @@ class ClientConfig:
 
     @property
     def ca_maxlen(self) -> int:
-        """CA队列最大长度（从 settings 单一真源读取）"""
+        """CA队列最大长度（帧数）：时间概念 ca_maxlen_seconds 在此边界按 raw_fps 换算为帧数。"""
         from app.settings import settings
-        return settings.ca_maxlen
+        return settings.ca_maxlen_seconds * settings.raw_fps
 
     @property
     def ca_segment_len(self) -> int:
-        """HLS段长度（帧数，从 settings 单一真源读取）"""
+        """HLS段长度（帧数）：时间概念 ca_segment_seconds 在此边界按 raw_fps 换算为帧数。"""
         from app.settings import settings
-        return settings.ca_segment_len
+        return settings.ca_segment_seconds * settings.raw_fps
 
     @property
     def inference_fps(self) -> int:

--- a/app/services/client/config.py
+++ b/app/services/client/config.py
@@ -103,19 +103,13 @@ class ClientConfig:
         return settings.ca_segment_seconds * settings.raw_fps
 
     @property
-    def inference_fps(self) -> int:
-        """推理帧率（从 settings 单一真源读取）"""
+    def inference_decimation(self) -> int:
+        """检测抽帧降采样倍率（从 settings 单一真源读取；抽帧器「每 N 帧留 1」）"""
         from app.settings import settings
-        return settings.inference_fps
-
-    @property
-    def raw_fps(self) -> int:
-        """原始/解码帧率（从 settings 单一真源读取；抽帧降采样率 = inference_fps/raw_fps）"""
-        from app.settings import settings
-        return settings.raw_fps
+        return settings.inference_decimation
 
     def cq_kwargs(self) -> Dict[str, Any]:
-        """组装 ClientQueues 构造参数（resize 属 client 配置，fps/队列走 settings 单一真源）。
+        """组装 ClientQueues 构造参数（resize 属 client 配置，采样倍率/队列走 settings 单一真源）。
 
         创建 CQ 的唯一配置出口：run 起始由 InferenceManager 调用（早于起流），
         避免"裸建默认值 + 起流时 kwargs 被丢弃"的 dead-kwargs 问题。
@@ -123,8 +117,7 @@ class ClientConfig:
         return {
             "resize_width": self.frame.resize_width,
             "resize_height": self.frame.resize_height,
-            "inference_fps": self.inference_fps,
-            "raw_fps": self.raw_fps,
+            "inference_decimation": self.inference_decimation,
             "ca_maxlen": self.ca_maxlen,
             "ca_segment_len": self.ca_segment_len,
         }
@@ -140,10 +133,10 @@ class ClientConfig:
                 self.ca_segment_len,
             )
             logger.debug(
-                "帧处理: %dx%d, inference_fps=%d",
+                "帧处理: %dx%d, 抽帧倍率 N=%d（每 N 帧留 1）",
                 self.frame.resize_width,
                 self.frame.resize_height,
-                self.inference_fps,
+                self.inference_decimation,
             )
             logger.debug(
                 "状态: timeout=%ds",
@@ -169,21 +162,8 @@ class ClientConfig:
                 f"会导致永远无法触发分段"
             )
 
-        # 检查inference_fps与全局配置冲突
-        try:
-            from app.settings import settings
-
-            global_inference_fps = getattr(settings, "inference_fps", None)
-            if (
-                global_inference_fps
-                and abs(self.inference_fps - int(global_inference_fps)) > 1
-            ):
-                warnings.append(
-                    f"⚠️  配置冲突: client.inference_fps({self.inference_fps}) "
-                    f"!= settings.inference_fps({global_inference_fps})"
-                )
-        except Exception:
-            pass
+        # 注：原 client.inference_fps ↔ settings.inference_fps 冲突检查已删——
+        # 采样倍率现单一真源 settings.inference_decimation，client 直读同源，无从冲突。
 
         # 输出警告
         if warnings:

--- a/app/services/client/queues.py
+++ b/app/services/client/queues.py
@@ -74,8 +74,7 @@ class ClientQueues:
         ca_maxlen: int = 2700,
         resize_width: int = 640,
         resize_height: int = 480,
-        inference_fps: int = 15,
-        raw_fps: int = 30,
+        inference_decimation: int = 2,
         *,
         # 不可变运行身份（primitives 直注，一次 CQ == 一次 run，终生不变）。
         # 全默认 None/"" 供纯队列/算子单测裸建；生产由 RunController 传入已解析好的
@@ -89,12 +88,11 @@ class ClientQueues:
         self.resize_width = resize_width
         self.resize_height = resize_height
 
-        # 帧率配置（降采样率 = inference_fps / raw_fps）
-        self.inference_fps = inference_fps
-        self.raw_fps = raw_fps
-        # 抽帧相位累加器（Bresenham 均匀抽帧）：仅由 decoder 线程读写
-        # （append_ca_ready_with_throttle 内部），无并发，不加锁
-        self._decimate_phase: int = 0
+        # 抽帧降采样倍率（每 N 帧留 1；N=raw_fps/检测率，如 30fps→15fps 取 N=2）。
+        # 抽帧器只需此整数倍率，不引用 raw_fps——源速率概念不进 CQ。
+        self.inference_decimation = inference_decimation
+        # 抽帧计数器：仅由 decoder 线程读写（append_ca_ready_with_throttle 内部），无并发，不加锁
+        self._decimate_counter: int = 0
 
         # --- 锁声明（顺序同 Lock Inventory 全清顺序）---
         self._raw_lock = threading.Lock()        # ca_raw + 帧缓存
@@ -170,26 +168,25 @@ class ClientQueues:
 
     def append_ca_ready_with_throttle(self, frame_data: Frame) -> bool:
         """
-        添加帧到待推理队列（Bresenham 相位累加器均匀抽帧 + 背压）。
+        添加帧到待推理队列（整数倍率均匀抽帧 + 背压）。
 
-        输入为 ffmpeg 规范化后的 CFR raw_fps 流，按 raw_fps→inference_fps 做均匀抽帧：
-        每个输入帧累加 inference_fps，跨过 raw_fps 阈值时放行一帧。长期保留率精确
-        = inference_fps/raw_fps（支持非整除比，如 30→20 取 keep-keep-drop），不依赖
-        wall-clock —— 消除解码线程调度抖动导致的真实率漂移（旧墙钟门把 15 漏成 ~12）。
+        输入为 ffmpeg 规范化后的 CFR 流：CFR 已把时间烙成等距帧号，故按**帧计数**「每 N 帧
+        留 1」即精确均匀降采样（N=inference_decimation），不依赖 wall-clock —— 消除解码线程
+        调度抖动导致的真实率漂移（旧墙钟门把 15 漏成 ~12）。整数计数天然精确、无浮点累积误差。
+        （整数因子只命中 raw_fps 的整除率；非整除比走不了，模型侧另按 ts 重采样到契约帧率。）
 
         ca_ready 为无锁 SPSC deque，decoder 是唯一写入方，dispatcher 是唯一消费方。
-        _decimate_phase 仅由本方法（decoder 线程）读写，无并发，不加锁。
+        _decimate_counter 仅由本方法（decoder 线程）读写，无并发，不加锁。
         """
-        # 写门：非 ACTIVE（拆除中/已关）拒写——在推进相位累加器之前拒，避免 late 帧扰动抽帧节奏。
+        # 写门：非 ACTIVE（拆除中/已关）拒写——在推进计数器之前拒，避免 late 帧扰动抽帧节奏。
         if self._state is not RunState.ACTIVE:
             return False
 
-        # 1. 相位累加器选帧：相位每输入帧推进一次（累加器正确性的不变式），
-        #    跨过 raw_fps 阈值才放行。
-        self._decimate_phase += self.inference_fps
-        if self._decimate_phase < self.raw_fps:
+        # 1. 整数倍率选帧：计数器每输入帧 +1，攒满 N 帧放行 1 帧（保留率精确 = 1/N）。
+        self._decimate_counter += 1
+        if self._decimate_counter < self.inference_decimation:
             return False
-        self._decimate_phase -= self.raw_fps
+        self._decimate_counter = 0
 
         # 2. 背压：仅对选中帧生效——推理队列满则丢（过载语义同旧）。
         max_len = self.ca_ready.maxlen

--- a/app/services/inference/instance.py
+++ b/app/services/inference/instance.py
@@ -13,5 +13,5 @@ from app.settings import settings
 
 inference_manager = InferenceManager(
     rt_fps=settings.raw_fps,
-    ca_segment_seconds=int(settings.ca_segment_len / settings.raw_fps),  # 帧数转秒
+    ca_segment_seconds=settings.ca_segment_seconds,  # 时间概念直取（秒），不再帧数往返换算
 )

--- a/app/services/inference/instance.py
+++ b/app/services/inference/instance.py
@@ -5,13 +5,10 @@
 `InferenceManager()` 构造较重（加载 stage 配置、建 worker 池），只应在消费方显式
 import 本模块时才构造，避免任何 `import app.services.inference.*` 触发 eager 构造。
 
-参数走 settings 单一真源（见 app/settings.py）。
+无需注入 fps/段长：CQ 段长真源在 ClientConfig.ca_segment_len（ca_segment_seconds×raw_fps），
+经 cq_kwargs 注入；可视化轮询率由 manager 内部直读 settings.inference_fps 派生。
 """
 
 from app.services.inference.manager import InferenceManager
-from app.settings import settings
 
-inference_manager = InferenceManager(
-    rt_fps=settings.raw_fps,
-    ca_segment_seconds=settings.ca_segment_seconds,  # 时间概念直取（秒），不再帧数往返换算
-)
+inference_manager = InferenceManager()

--- a/app/services/inference/manager.py
+++ b/app/services/inference/manager.py
@@ -40,13 +40,8 @@ class InferenceManager:
 
     def __init__(
         self,
-        rt_fps: int = 30,
-        ca_segment_seconds: int = 10,
         db_dir: Optional[str] = None,
     ):
-        # 队列参数
-        self._ca_segment_len = max(10, int(rt_fps * ca_segment_seconds))
-
         # 持久化存储根目录：默认读 settings 单一真源（与 persistence/traceback 同源），
         # 仅显式传 db_dir 时覆盖（测试/特殊场景）。不再 __file__ 自数层级重算。
         from app.settings import settings

--- a/app/services/inference/manager.py
+++ b/app/services/inference/manager.py
@@ -2,13 +2,13 @@
 
 架构特点：
 1. 推理与可视化解耦：推理线程只负责推理，可视化独立定时拉取
-2. 时序分析独立：ClientTemporalActor 持有 Operator 流算子（per-client），1Hz tick
+2. 时序分析独立：ClientTemporalActor 持有 Operator 流算子（per-client），2Hz tick
 3. 三池独立时钟：推理、时序分析、可视化各自独立节奏，不通过队列串联
 4. 双写 + 原子快照：推理结果同时写入 slide_window（历史）和 latest_inference（最新快照）
 
 数据流：
 InferenceLoop → cq.push_detection() + cq.set_latest_inference()  [双写]
-TemporalActor (1Hz)  → cq.get_slide_window() → operator.analyze() → operator.judge() → cq.set_latest_temporal()
+TemporalActor (2Hz)  → cq.get_slide_window() → operator.analyze() → operator.judge() → cq.set_latest_temporal()
 VisualizationWorker (~15Hz) → cq.get_latest_inference() + get_latest_frame() + get_latest_temporal() → render → cq
 """
 
@@ -32,7 +32,7 @@ class InferenceManager:
 
     集成三个独立时钟的 Worker 池：
     - ModelWorkerService（推理，~30 FPS）
-    - ClientTemporalActor（时序分析，1 Hz，per-client）
+    - ClientTemporalActor（时序分析，2 Hz，per-client）
     - VisualizationWorkerPool（可视化，~15 FPS）
 
     三池通过 ClientQueues 上的原子槽位通信，不通过队列串联。

--- a/app/services/inference/manager.py
+++ b/app/services/inference/manager.py
@@ -64,8 +64,10 @@ class InferenceManager:
         # （T3 已落地），本类不再自持 _client_lifecycle_lock。
         self._actors: Dict[int, ClientTemporalActor] = {}
 
-        # 可视化拉取率 = settings.inference_fps（单一真源）：与推理限流、HLS processed
-        # 打标三处对齐，避免 processed 段实际产出率 ≠ 打标率导致回放偏快。
+        # 可视化 worker 是"采样后 inference 流"的消费者：渲染按 inference.ts 去重，故轮询率
+        # 必须 = 该流速率（检测采样率 settings.inference_fps）——快则空转、慢则丢帧。
+        # 这是"消费者继承源流速率"的合法派生，非 fps 上帝常量；HLS processed 打标另由 eff_fps
+        # 从 ts 反推、模型输入另由 model_input_fps 契约重采样，二者已不再借用本值。
         self.visualization_pool = VisualizationWorkerPool(
             target_fps=settings.inference_fps,
             stage_configs=None,

--- a/app/services/inference/temporal/__init__.py
+++ b/app/services/inference/temporal/__init__.py
@@ -1,7 +1,7 @@
 """时序分析层 (L3/L4)。
 
 抽象：Operator（operator.py，合并 analyze 推进状态 + judge 出告警；消费帧窗 List[FrameFeature]）
-处理流程：ClientTemporalActor 每 Client 1Hz tick（actor.py）→ 告警经 alarm_sink.persist_alarms
+处理流程：ClientTemporalActor 每 Client 2Hz tick（actor.py）→ 告警经 alarm_sink.persist_alarms
 过闸 + 落库（alarm_sink.py 编排 client 侧过闸 + persistence 无状态落库；actor 只在产出处把
 stage 别名烧进 alarm.stage）。
 

--- a/app/services/inference/temporal/actor.py
+++ b/app/services/inference/temporal/actor.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class ClientTemporalActor:
-    """per-client 时序分析 actor（注册多个流算子，1Hz 驱动）。
+    """per-client 时序分析 actor（注册多个流算子，2Hz 驱动）。
 
     每个 client 独立一个实例，故障互不影响。
     状态机（_sm）封装在各 Operator 内部，actor 不持有外部 sm 字典。
@@ -37,7 +37,9 @@ class ClientTemporalActor:
         cq,                              # ClientQueues
         stage: str,
         operators: List[Operator],
-        tick_interval: float = 1.0,
+        # tick 间隔（秒，时间域）= 全局唯一 tick 真源：manager 构造时不覆盖，默认即生产值。
+        # 0.5s → 2Hz：判定/告警上升沿延迟减半；单算子 analyze<12ms、预算 500ms 仍宽裕。
+        tick_interval: float = 0.5,
     ):
         self._task_id = task_id
         self._cq = cq

--- a/app/services/inference/temporal/operator.py
+++ b/app/services/inference/temporal/operator.py
@@ -95,6 +95,20 @@ class TemporalOperator(Operator):
             raise ValueError(
                 f"[{name}] model_input_fps 必须为正（得到 {model_input_fps}）"
             )
+        # 上界：重采样只能降采样（_resample_by_ts 网格抽稀）。契约帧率 > 检测采样率时无法达成——
+        # 窗口本就没那么密，重采样保留全帧、实际喂检测率而非契约率 → 静默 skew。故加载期即拒，
+        # 别放行成"假达标"。检测采样率 = raw_fps / inference_decimation = settings.inference_fps。
+        from app.settings import settings
+        detection_fps = settings.inference_fps
+        # 相对容差比较：非整除采样率（如 30/7=4.2857…）反推出的 detection_fps 是循环二进制小数，
+        # 与 yaml 里"顶到上限"的十进制字面量可能差 1 ULP。顶格是合法配置（重采样恰为 no-op），
+        # 不能因浮点抖动误拒；容差 1e-9 远小于任何真实"超限"（如 20 vs 15），不放过真错。
+        if model_input_fps > detection_fps * (1.0 + 1e-9):
+            raise ValueError(
+                f"[{name}] model_input_fps({model_input_fps}) > 检测采样率"
+                f"({detection_fps:.3f} = raw_fps/inference_decimation)：重采样只能降采样，"
+                f"契约帧率不可高于检测采样率（要么降 model_input_fps、要么减小 inference_decimation）"
+            )
         self.model_input_fps: float = float(model_input_fps)
 
         self._object_id_to_name = objects

--- a/app/services/inference/temporal/operator.py
+++ b/app/services/inference/temporal/operator.py
@@ -79,6 +79,7 @@ class TemporalOperator(Operator):
         model_path: str,
         objects: Dict[int, str],
         actions: Dict[int, str],
+        model_input_fps: Optional[float] = None,
     ):
         super().__init__(name, subscribes, window_seconds)
         if not model_path:
@@ -86,6 +87,21 @@ class TemporalOperator(Operator):
         self.model_path = model_path
         self.num_objects = len(objects)
         self.num_actions = len(actions)
+
+        # 模型契约帧率：入模前把窗口按 ts 重采样到此帧率（消 train/serve skew）。
+        # 必须等于训练 fps；配错不崩、静默降级——故加载期即在此暴露信号。
+        if model_input_fps is None:
+            self.model_input_fps: Optional[float] = None
+            logger.warning(
+                "[%s] 未声明 model_input_fps：跳过入模重采样，直接喂检测采样率窗口"
+                "（若训练 fps ≠ 检测采样率则有 train/serve skew）", name,
+            )
+        elif model_input_fps <= 0:
+            raise ValueError(
+                f"[{name}] model_input_fps 必须为正（得到 {model_input_fps}）"
+            )
+        else:
+            self.model_input_fps = float(model_input_fps)
 
         self._object_id_to_name = objects
         self._action_id_to_name = actions
@@ -112,6 +128,27 @@ class TemporalOperator(Operator):
     
     def _action_name(self, action_id: int) -> str:
         return self._action_id_to_name.get(action_id, f"action_{action_id}")
+
+    def _resample_by_ts(self, frames: List[FrameFeature]) -> List[FrameFeature]:
+        """按帧 ts 把窗口重采样到 model_input_fps（消 train/serve skew）。
+
+        相位网格抽稀：从首帧起维护理想采样时刻 next_t，每步 += 1/model_input_fps，保留
+        首个 ts ≥ next_t 的帧。网格前进（非从"上一保留帧"累加）→ 不累积舍入漂移，2:1
+        比例下稳定取到目标帧率；遇缺口令网格落后当前帧时重锚，避免追补突发。
+        纯 ts 函数——不改帧内容、不合成新 ts。未声明契约帧率则原样返回。
+        """
+        if self.model_input_fps is None or len(frames) < 2:
+            return frames
+        min_dt = 1.0 / self.model_input_fps
+        kept = [frames[0]]
+        next_t = frames[0].ts + min_dt
+        for f in frames[1:]:
+            if f.ts >= next_t:
+                kept.append(f)
+                next_t += min_dt
+                if next_t <= f.ts:  # 缺口致网格落后：重锚到当前帧，避免追补突发
+                    next_t = f.ts + min_dt
+        return kept
 
     def _try_load_model(self) -> bool:
         """惰性加载时序模型 （首次推理时触发，双重检查锁保证线程安全）。"""

--- a/app/services/inference/temporal/operator.py
+++ b/app/services/inference/temporal/operator.py
@@ -79,7 +79,7 @@ class TemporalOperator(Operator):
         model_path: str,
         objects: Dict[int, str],
         actions: Dict[int, str],
-        model_input_fps: Optional[float] = None,
+        model_input_fps: float,
     ):
         super().__init__(name, subscribes, window_seconds)
         if not model_path:
@@ -88,20 +88,14 @@ class TemporalOperator(Operator):
         self.num_objects = len(objects)
         self.num_actions = len(actions)
 
-        # 模型契约帧率：入模前把窗口按 ts 重采样到此帧率（消 train/serve skew）。
-        # 必须等于训练 fps；配错不崩、静默降级——故加载期即在此暴露信号。
-        if model_input_fps is None:
-            self.model_input_fps: Optional[float] = None
-            logger.warning(
-                "[%s] 未声明 model_input_fps：跳过入模重采样，直接喂检测采样率窗口"
-                "（若训练 fps ≠ 检测采样率则有 train/serve skew）", name,
-            )
-        elif model_input_fps <= 0:
+        # 模型契约帧率：入模前把窗口按 ts 重采样到此帧率（消 train/serve skew）。必须等于训练 fps。
+        # 漏配/配错不崩管线、只静默降级（喂错帧率 → 误分类），故设为必填、加载期即校验暴露：
+        # yaml 漏 key → 构造缺参 TypeError；给了非正值 → 此处 ValueError。
+        if model_input_fps is None or model_input_fps <= 0:
             raise ValueError(
                 f"[{name}] model_input_fps 必须为正（得到 {model_input_fps}）"
             )
-        else:
-            self.model_input_fps = float(model_input_fps)
+        self.model_input_fps: float = float(model_input_fps)
 
         self._object_id_to_name = objects
         self._action_id_to_name = actions
@@ -135,9 +129,9 @@ class TemporalOperator(Operator):
         相位网格抽稀：从首帧起维护理想采样时刻 next_t，每步 += 1/model_input_fps，保留
         首个 ts ≥ next_t 的帧。网格前进（非从"上一保留帧"累加）→ 不累积舍入漂移，2:1
         比例下稳定取到目标帧率；遇缺口令网格落后当前帧时重锚，避免追补突发。
-        纯 ts 函数——不改帧内容、不合成新 ts。未声明契约帧率则原样返回。
+        纯 ts 函数——不改帧内容、不合成新 ts。帧数 < 2 无从抽稀，原样返回。
         """
-        if self.model_input_fps is None or len(frames) < 2:
+        if len(frames) < 2:
             return frames
         min_dt = 1.0 / self.model_input_fps
         kept = [frames[0]]

--- a/app/services/inference/temporal/operator.py
+++ b/app/services/inference/temporal/operator.py
@@ -107,7 +107,7 @@ class TemporalOperator(Operator):
         self._model: torch.nn.Module = None
         self._model_load_lock = threading.Lock()
         self._load_failed = False
-        # 时序 GRU 是小模型（输入48维/隐层64/3层双向）+ 1Hz 推理，实测 CPU 单次 <12ms（预算1000ms）。
+        # 时序 GRU 是小模型（输入48维/隐层64/3层双向）+ 2Hz 推理，实测 CPU 单次 <12ms（预算500ms）。
         # 固定 CPU：H2D/D2H 拷贝与 kernel launch 开销盖过本体计算，GPU 留给 YOLO 专用（离线 BiGRU 亦为 CPU）。
         self._device = torch.device("cpu")
 

--- a/app/services/inference/visualization/pool.py
+++ b/app/services/inference/visualization/pool.py
@@ -19,8 +19,9 @@ class VisualizationWorkerPool:
 
     单线程理由：单帧渲染 ~5ms，@20FPS 时 tick 预算 50ms，约可覆盖 10 clients；
     单线程避免了多线程竞争同一客户端的问题。
-    实际 target_fps 由调用方注入 settings.inference_fps（与推理限流、HLS processed
-    打标对齐），默认值仅作脱离装配时的兜底。
+    实际 target_fps 由调用方注入 settings.inference_fps——viz 是"采样后 inference 流"的
+    消费者，poll 率跟随该流速率（渲染按 inference.ts 去重，快则空转、慢则丢帧），属合法
+    派生而非共用旋钮；HLS processed 打标已改走 eff_fps、不再共享此值。默认值仅作脱离装配时的兜底。
     """
 
     def __init__(

--- a/app/services/inference/workflows/claude.md
+++ b/app/services/inference/workflows/claude.md
@@ -46,7 +46,7 @@ flowchart TD
 
 | 模式 | 触发时机 | 来源方法 | 去向 |
 | ------ | --------- | --------- | ------ |
-| 实时告警 | TemporalActor 1Hz 轮询，`operator.analyze()` 推进状态 → `operator.judge()` 上升沿触发 | `Operator.judge()` | persist_alarm → 30s 批次 → HTTP POST 外部数据库 |
+| 实时告警 | TemporalActor 2Hz 轮询，`operator.analyze()` 推进状态 → `operator.judge()` 上升沿触发 | `Operator.judge()` | persist_alarm → 30s 批次 → HTTP POST 外部数据库 |
 | 结算告警 | 任务 terminate 时调用一次 | `Operator.finalize()` | 同上，由 `ClientTemporalActor.finalize_and_stop()` 收集、`InferenceManager._persist_settlement_alarms()` 驱动 |
 
 > **UI 通知**：`events`（字符串列表）经 VisualizationWorker 渲染为视频帧 overlay，通过 WebSocket 实时推送给前端。`AlarmInfo` 只走持久化，不直接推给前端。

--- a/app/services/inference/workflows/clean.py
+++ b/app/services/inference/workflows/clean.py
@@ -13,7 +13,7 @@ detector.name = 该 detector 产出的流名（决定 slide_window key 与 Opera
 
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
@@ -112,6 +112,7 @@ class CleanOperator(TemporalOperator):
         model_path: str,
         actions: Dict[int, str],
         objects: Dict[int, str],
+        model_input_fps: Optional[float] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -120,6 +121,7 @@ class CleanOperator(TemporalOperator):
             model_path=model_path,
             actions=actions,
             objects=objects,
+            model_input_fps=model_input_fps,
         )
         self._sm = {
             "last_ts": 0.0,
@@ -147,7 +149,10 @@ class CleanOperator(TemporalOperator):
         if not new_frames:
             return
 
-        features = self._adapt_to_features(aligned_frames)
+        # 入模前按 ts 重采样到模型契约帧率（检测采样率 → model_input_fps），消 train/serve skew。
+        # 新帧门 / last_ts 推进仍基于完整 aligned_frames，重采样只决定喂给模型的时间轴密度。
+        model_frames = self._resample_by_ts(aligned_frames)
+        features = self._adapt_to_features(model_frames)
         if features.numel() == 0:
             return
 

--- a/app/services/inference/workflows/clean.py
+++ b/app/services/inference/workflows/clean.py
@@ -13,7 +13,7 @@ detector.name = 该 detector 产出的流名（决定 slide_window key 与 Opera
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import torch
 
@@ -112,7 +112,7 @@ class CleanOperator(TemporalOperator):
         model_path: str,
         actions: Dict[int, str],
         objects: Dict[int, str],
-        model_input_fps: Optional[float] = None,
+        model_input_fps: float,
     ) -> None:
         super().__init__(
             name=name,

--- a/app/services/lab/clip_builder.py
+++ b/app/services/lab/clip_builder.py
@@ -313,20 +313,28 @@ class ClipBuilder:
                 f"(fMP4 fragment 段需要 EXT-X-MAP 才能解码)"
             )
 
-        # 临时 m3u8 落在 step 目录，让 EXT-X-MAP/EXTINF 的相对 URI 能解析到 init.mp4 与各段
+        # 临时 m3u8 落在 step 目录，让 EXT-X-MAP/EXTINF 的相对 URI 能解析到 init.mp4 与各段。
+        # 每段 EXTINF 用相邻段 ts 跨度（实测墙钟），而非假定固定 10s——offset_us 的 seek 基准
+        # 本就是 ts，固定时长在 fps 漂移下会让累计 EXTINF 偏离墙钟、seek 逐段错位。窗口已过
+        # _validate_continuity（无真实录制停顿），故相邻段连续、ts 跨度 ≈ 段媒体时长；末段用中位估算兜底。
         nonce = secrets.token_hex(4)
         tmp_m3u8 = step_dir / f".clip_{nonce}.m3u8"
-        ext_inf_s = self._default_seg_dur_us / 1_000_000.0
+        est_dur_us = _est_segment_duration_us(segs, self._default_seg_dur_us)
+        seg_durs_us = [
+            (segs[i + 1].ts_us - segs[i].ts_us) if i + 1 < len(segs) else est_dur_us
+            for i in range(len(segs))
+        ]
+        target_dur_s = max(seg_durs_us) / 1_000_000.0 if seg_durs_us else 10.0
 
         lines = [
             "#EXTM3U",
             "#EXT-X-VERSION:7",
             "#EXT-X-PLAYLIST-TYPE:VOD",
-            f"#EXT-X-TARGETDURATION:{int(ext_inf_s) + 1}",
+            f"#EXT-X-TARGETDURATION:{int(target_dur_s) + 1}",
             '#EXT-X-MAP:URI="init.mp4"',
         ]
-        for s in segs:
-            lines.append(f"#EXTINF:{ext_inf_s:.3f},")
+        for s, dur_us in zip(segs, seg_durs_us):
+            lines.append(f"#EXTINF:{dur_us / 1_000_000.0:.3f},")
             lines.append(s.path.name)
         lines.append("#EXT-X-ENDLIST")
         tmp_m3u8.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/app/services/lab/clip_builder.py
+++ b/app/services/lab/clip_builder.py
@@ -324,7 +324,8 @@ class ClipBuilder:
             (segs[i + 1].ts_us - segs[i].ts_us) if i + 1 < len(segs) else est_dur_us
             for i in range(len(segs))
         ]
-        target_dur_s = max(seg_durs_us) / 1_000_000.0 if seg_durs_us else 10.0
+        # segs 非空由方法开头 segs[0].ts_us 解引用保证 → seg_durs_us 必非空，max() 无需兜底。
+        target_dur_s = max(seg_durs_us) / 1_000_000.0
 
         lines = [
             "#EXTM3U",

--- a/app/services/persistence/config.py
+++ b/app/services/persistence/config.py
@@ -101,20 +101,10 @@ class PersistenceConfig:
         Returns:
             PersistenceConfig实例
         """
-        # 仅取已知字段，防御性兼容仍残留 base_dir 的旧 yaml（静默忽略而非崩）
-        storage_raw = config_dict.get("storage", {})
-        storage_kwargs = {
-            k: v for k, v in storage_raw.items()
-            if k in StorageConfig.__dataclass_fields__
-        }
-        storage = StorageConfig(**storage_kwargs)
-        # 同样防御性过滤：兼容仍残留已废字段（如旧 yaml 的 segment_duration）的 hls 块
-        hls_raw = config_dict.get("hls", {})
-        hls_kwargs = {
-            k: v for k, v in hls_raw.items()
-            if k in HLSConfig.__dataclass_fields__
-        }
-        hls = HLSConfig(**hls_kwargs)
+        # yaml 由 git 跟踪、每次部署整仓覆盖为干净版，磁盘不会残留已废字段；
+        # 故不做字段过滤——真出未知字段就让它响亮地崩，别静默吞。
+        storage = StorageConfig(**config_dict.get("storage", {}))
+        hls = HLSConfig(**config_dict.get("hls", {}))
         alarm = AlarmConfig(**config_dict.get("alarm", {}))
         return cls(storage=storage, hls=hls, alarm=alarm)
 

--- a/app/services/persistence/config.py
+++ b/app/services/persistence/config.py
@@ -20,9 +20,10 @@ class HLSConfig:
 
     workers: int = 2
     queue_size: int = 100
-    segment_duration: int = 10
     sweep_interval_seconds: float = 1.0  # HLSSegmentSweeper 扫描间隔（秒，PULL 模型）
-    # 注意：raw_fps和processed_fps从inference config动态获取，不在此定义
+    # 注意：不配 segment_duration——分段由 CQ 帧数(ca_segment_len)触发、每段时长由 EXTINF
+    #      从帧 ts 自适应，回放侧也从 EXTINF 读；此处配任何时长都是死值、且会误导。
+    # 注意：HLS 段编码帧率由 strategy 从帧 ts 自适应反推（eff_fps），不在此配置任何 fps
 
 
 @dataclass
@@ -107,7 +108,13 @@ class PersistenceConfig:
             if k in StorageConfig.__dataclass_fields__
         }
         storage = StorageConfig(**storage_kwargs)
-        hls = HLSConfig(**config_dict.get("hls", {}))
+        # 同样防御性过滤：兼容仍残留已废字段（如旧 yaml 的 segment_duration）的 hls 块
+        hls_raw = config_dict.get("hls", {})
+        hls_kwargs = {
+            k: v for k, v in hls_raw.items()
+            if k in HLSConfig.__dataclass_fields__
+        }
+        hls = HLSConfig(**hls_kwargs)
         alarm = AlarmConfig(**config_dict.get("alarm", {}))
         return cls(storage=storage, hls=hls, alarm=alarm)
 
@@ -130,10 +137,6 @@ class PersistenceConfig:
     @property
     def hls_queue_size(self) -> int:
         return self.hls.queue_size
-
-    @property
-    def segment_duration(self) -> int:
-        return self.hls.segment_duration
 
     @property
     def hls_sweep_interval_seconds(self) -> float:
@@ -159,18 +162,6 @@ class PersistenceConfig:
     def cleanup_interval_seconds(self) -> int:
         return self.storage.cleanup_interval_seconds
 
-    @property
-    def raw_fps(self) -> float:
-        """原始视频帧率（从 settings 单一真源读取）"""
-        from app.settings import settings
-        return float(settings.raw_fps)
-
-    @property
-    def processed_fps(self) -> float:
-        """处理后视频帧率（从 settings 单一真源读取 inference_fps）"""
-        from app.settings import settings
-        return float(settings.inference_fps)
-
     def _log_loaded_config(self):
         """输出加载的配置（启动时显示）"""
         # DEBUG级别显示详细配置
@@ -178,11 +169,9 @@ class PersistenceConfig:
             logger.debug("========== Persistence配置 ==========")
             logger.debug("存储: base_dir=%s", self.storage_base_dir)
             logger.debug(
-                "HLS: workers=%d, queue=%d, raw_fps=%.1f, processed_fps=%.1f",
+                "HLS: workers=%d, queue=%d",
                 self.hls.workers,
                 self.hls.queue_size,
-                self.raw_fps,
-                self.processed_fps,
             )
             logger.debug(
                 "告警: workers=%d, queue=%d",
@@ -195,7 +184,7 @@ class PersistenceConfig:
                 self.storage.cleanup_days,
             )
             logger.debug(
-                "📌 fps参数来源: app/settings.py (raw_fps, inference_fps，单一真源)"
+                "📌 HLS 段编码帧率由 strategy 从帧 ts 自适应反推(eff_fps)，配置层不持 fps"
             )
             logger.debug("=====================================")
 
@@ -203,8 +192,7 @@ class PersistenceConfig:
         """配置验证和冲突检测"""
         warnings = []
 
-        # 1. 检查processed_fps是否与inference config一致（由inference模块检查）
-        # 这里不做检查，避免循环依赖
+        # 1. HLS 段编码帧率由 strategy 从帧 ts 反推，配置层不再持 fps，无 fps 一致性校验。
 
         # 2. 检查队列容量合理性
         if self.hls.queue_size < 100:

--- a/app/services/persistence/manager.py
+++ b/app/services/persistence/manager.py
@@ -55,9 +55,6 @@ class PersistenceManager:
             input_queue=self.hls_queue,
             num_workers=self.config.hls_workers,
             db_dir=self.config.storage_base_dir,
-            segment_duration=self.config.segment_duration,
-            raw_fps=self.config.raw_fps,
-            processed_fps=self.config.processed_fps,
         )
 
         self.alarm_pool = AlarmWorkerPool(

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -501,7 +501,9 @@ class HLSPersistenceStrategy:
 
         start_ts = frames[0].timestamp
 
-        # 1. 生成原始视频段（使用原始视频源帧率30fps）
+        # 1. 生成原始视频段：帧率从帧 ts 反推（与 processed 段同款），raw_fps 仅作 fallback。
+        # 解码 CFR 名义 30，但实际可漂移；用实测 eff_fps 让回放速率贴合真实墙钟。
+        eff_fps = self._effective_fps(frames, self.raw_fps)
         raw_segment_path = target_dir / f"raw_segment_{int(start_ts * 1e6)}.mp4"
         height, width = frames[0].frame.shape[:2]
         fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore[attr-defined]
@@ -509,7 +511,7 @@ class HLSPersistenceStrategy:
         out_raw = None
         try:
             out_raw = cv2.VideoWriter(
-                str(raw_segment_path), fourcc, self.raw_fps, (width, height)
+                str(raw_segment_path), fourcc, eff_fps, (width, height)
             )
             for fd in frames:
                 out_raw.write(fd.frame)
@@ -524,10 +526,10 @@ class HLSPersistenceStrategy:
                 out_raw.release()  # 异常路径也须释放原生编码器句柄
 
         # 2. 计算视频段时长：必须与 fMP4 fragment 实际媒体时长完全一致。
-        # cv2.VideoWriter 用固定 fps 写 N 帧 → 输出 mp4v 媒体时长 = N/fps，
-        # ffmpeg 转码到 fMP4 保持该时长。EXTINF 用 wall-clock 帧时间戳差会引入抖动，
-        # 与 fragment 实际时长偏差 0.5+ 秒 → hls.js 段尾 MSE 缓冲洞 → 卡死 + 总时长缩水。
-        segment_duration = len(frames) / self.raw_fps
+        # cv2.VideoWriter 用 eff_fps 写 N 帧 → 输出 mp4v 媒体时长 = N/eff_fps，
+        # ffmpeg 转码到 fMP4 保持该时长。故 EXTINF 必须同用 eff_fps（与写入帧率一致），
+        # 否则与 fragment 实际时长偏差 → hls.js 段尾 MSE 缓冲洞 → 卡死 + 总时长缩水。
+        segment_duration = len(frames) / eff_fps
 
         # 3 & 4. 持锁完成：transcode（含 ts_offset 读 playlist）+ playlist append + metadata。
         # 三段必须原子，否则相邻段 transcode 会读到相同累计 EXTINF → tfdt 碰撞。

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -28,6 +28,15 @@ from app.utils.exceptions import PersistenceError
 
 logger = logging.getLogger(__name__)
 
+# HLS 段的编码帧率正常由 `_effective_fps` 从帧 ts 反推（完全自适应，不引用任何上游 fps）。
+# 以下三个常量定义"无可测速率"的退化判定与兜底，全部具名、不散落在条件里：
+#   _EFF_FPS_MIN / _EFF_FPS_MAX —— 反推值的合理带；落带外（乱序/重复 ts 致 span 异常）视为不可信。
+#   _DEGENERATE_FALLBACK_FPS   —— 单帧段 / span<=0 / 带外 时的兜底。此时本就无时序信息，
+#       取值与上游 fps 无关，只需给退化的单帧段一个合理 EXTINF；故用本地常量而非上游 raw_fps/inference_fps。
+_EFF_FPS_MIN = 1.0
+_EFF_FPS_MAX = 60.0
+_DEGENERATE_FALLBACK_FPS = 15.0
+
 
 class HLSPersistenceStrategy:
     """HLS持久化策略"""
@@ -35,30 +44,28 @@ class HLSPersistenceStrategy:
     def __init__(
         self,
         db_dir: Path,
-        raw_fps: float = 30.0,
-        processed_fps: float = 20.0,
     ):
         self.db_dir = db_dir
-        self.raw_fps = raw_fps
-        self.processed_fps = processed_fps
+        # HLS 段编码帧率全程从帧 ts 反推（见 _effective_fps），不接收任何上游 fps。
         # 按 target_dir 路径索引的细粒度锁，序列化同一任务目录下的 playlist/metadata 写操作
         self._dir_locks: Dict[str, threading.Lock] = {}
         self._dir_locks_guard = threading.Lock()
 
     @staticmethod
-    def _effective_fps(frames: List[Frame], fallback: float) -> float:
+    def _effective_fps(frames: List[Frame]) -> float:
         """由帧时间戳跨度反推有效编码 fps：`(N-1) / (ts_last - ts_first)`。
 
-        VideoWriter 与 EXTINF 须用同一个返回值，回放才对齐墙钟。span<=0 / 单帧 / 反推值落在
-        合理带 [1, 60] 外（重复或乱序时间戳致 span 异常）时回退标称 `fallback`。
+        VideoWriter 与 EXTINF 须用同一个返回值，回放才对齐墙钟。raw/processed 段一律走此
+        自适应反推、不引用上游 fps。span<=0 / 单帧 / 反推值落在合理带 [1, 60] 外（重复或
+        乱序时间戳致 span 异常）时——即无可测速率的退化段——回退 `_DEGENERATE_FALLBACK_FPS`。
         """
         if len(frames) > 1:
             span = frames[-1].timestamp - frames[0].timestamp
             if span > 0:
                 eff_fps = (len(frames) - 1) / span
-                if 1.0 <= eff_fps <= 60.0:
+                if _EFF_FPS_MIN <= eff_fps <= _EFF_FPS_MAX:
                     return eff_fps
-        return fallback
+        return _DEGENERATE_FALLBACK_FPS
 
     def _get_dir_lock(self, target_dir: Path) -> threading.Lock:
         key = str(target_dir)
@@ -501,9 +508,9 @@ class HLSPersistenceStrategy:
 
         start_ts = frames[0].timestamp
 
-        # 1. 生成原始视频段：帧率从帧 ts 反推（与 processed 段同款），raw_fps 仅作 fallback。
+        # 1. 生成原始视频段：帧率从帧 ts 反推（与 processed 段同款），无可测速率时退化兜底。
         # 解码 CFR 名义 30，但实际可漂移；用实测 eff_fps 让回放速率贴合真实墙钟。
-        eff_fps = self._effective_fps(frames, self.raw_fps)
+        eff_fps = self._effective_fps(frames)
         raw_segment_path = target_dir / f"raw_segment_{int(start_ts * 1e6)}.mp4"
         height, width = frames[0].frame.shape[:2]
         fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore[attr-defined]
@@ -592,11 +599,11 @@ class HLSPersistenceStrategy:
         start_ts = frames[0].timestamp
 
         # 0. 按本段帧时间戳跨度反推有效 fps：processed 实际成帧率随 throttle / 渲染尖峰
-        # 在窗口间漂移（~11-15fps），固定 processed_fps 编码会按 20/真实率 倍快放，且
+        # 在窗口间漂移（~11-15fps），固定名义帧率编码会按 兜底/真实率 倍快放，且
         # 逐段速率不同 → 段间忽快忽慢的抖动。逐段各取自身 eff_fps，VideoWriter 与 EXTINF
         # 同源 → 每段播成 1.0x，对齐墙钟、抖动消失。详见
         # docs/update/20260629_PROCESSED_PLAYBACK_RATE_PROPOSAL.md。
-        eff_fps = self._effective_fps(frames, self.processed_fps)
+        eff_fps = self._effective_fps(frames)
 
         # 1. 生成处理后视频段（使用实测有效帧率 eff_fps）
         segment_path = target_dir / f"processed_segment_{int(start_ts * 1e6)}.mp4"

--- a/app/services/persistence/workers/hls_worker.py
+++ b/app/services/persistence/workers/hls_worker.py
@@ -76,19 +76,14 @@ class HLSWorkerPool:
         input_queue: Queue,
         num_workers: int = 2,
         db_dir: Path | None = None,
-        segment_duration: int = 10,
-        raw_fps: float = 30.0,
-        processed_fps: float = 20.0,
     ):
         self.input_queue = input_queue
         self.num_workers = num_workers
         self.stop_event = threading.Event()
 
-        # 创建持久化策略
+        # 创建持久化策略（编码帧率全程从帧 ts 自适应反推，不接收上游 fps）
         self.strategy = HLSPersistenceStrategy(
             db_dir=db_dir or Path("database"),
-            raw_fps=raw_fps,
-            processed_fps=processed_fps,
         )
 
         # 创建Worker

--- a/app/services/stream/config.py
+++ b/app/services/stream/config.py
@@ -6,11 +6,13 @@
 """
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import yaml
+
+from app.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +23,9 @@ class DecoderConfig:
 
     default_width: int = 640
     default_height: int = 480
-    default_fps: int = 30
+    # 解码 CFR = 生产者源，单一真源 settings.raw_fps（ffmpeg 强制 CFR、下游全部派生）。
+    # 不在 stream_config.yaml 里再写死一个 fps，否则又成第二个"巧合相等"的独立源。
+    default_fps: int = field(default_factory=lambda: settings.raw_fps)
     pix_fmt: str = "bgr24"
     chunk_read_size: int = 32768
     backpressure_ratio: float = 0.90  # 队列达到90%时丢帧

--- a/app/settings.py
+++ b/app/settings.py
@@ -90,9 +90,11 @@ class Settings(BaseSettings):
 
     # 视频/推理帧率与队列（跨模块单一真源；inference / stream / client / persistence 四方共读，
     # 不再寄生在 inference_config.yaml 的 global 块里互相反向依赖）。env: CLEANSIGHT_RAW_FPS 等。
-    raw_fps: int = 30          # 生产者源：解码 CFR 帧率（decoder default_fps、HLS raw fallback 全派生自此）
-    inference_fps: int = 15    # 采样器：检测抽帧采样率——系统唯一 fps 旋钮（queues Bresenham 抽帧）。
-                               # 取 30 的整除值；不再被 HLS processed/client 限流/模型输入借用（各自派生/契约化）。
+    raw_fps: int = 30          # 生产者源：解码 CFR 帧率（decoder default_fps、HLS raw fallback、CA 秒→帧数换算全派生自此）
+    inference_decimation: int = 2  # 采样器：检测抽帧降采样倍率——系统唯一采样旋钮。抽帧器「每 N 帧留 1」直接用它。
+                               # 检测率 = raw_fps / N（N=2→15fps，派生见 inference_fps property）。整数因子故只能命中
+                               # raw_fps 的整除率（30→15/10/7.5/6…，不支持 30→20 类非整除比）；模型侧另按 ts 重采样到 7.5。
+                               # env: CLEANSIGHT_INFERENCE_DECIMATION
     # CA 缓存/段长本是"时间概念"，以秒声明（时间为跨子系统货币）；帧数在各消费边界按 raw_fps 显式换算。
     ca_maxlen_seconds: int = 90    # CA 队列缓存时长（秒）→ 帧数 = ×raw_fps
     ca_segment_seconds: int = 10   # HLS 段时长（秒）→ 帧数 = ×raw_fps
@@ -131,6 +133,16 @@ class Settings(BaseSettings):
     lab_export_max_total_ms: int = 1_800_000  # 一次提交总时长上限（30 min）
     lab_export_max_clips_per_submit: int = 20
     lab_export_gap_tolerance_ms: int = 2000   # 相邻段间隔相对 step 实测节奏的允许超出量；>此值判为真录制停顿（源断流/重连）
+
+    @property
+    def inference_fps(self) -> float:
+        """检测抽帧后的有效帧率（派生：raw_fps / inference_decimation）。
+
+        供需要绝对速率的消费者读（如 viz 轮询率）；抽帧器本身只用整数倍率
+        inference_decimation「每 N 帧留 1」，不做此除法。派生化后无从被设成与
+        raw_fps/N 不一致的值（消漂移）。N 非整除 raw_fps 时为小数（如 30/4=7.5）。
+        """
+        return self.raw_fps / self.inference_decimation
 
     @property
     def allowed_ips_set(self) -> frozenset:

--- a/app/settings.py
+++ b/app/settings.py
@@ -90,11 +90,12 @@ class Settings(BaseSettings):
 
     # 视频/推理帧率与队列（跨模块单一真源；inference / stream / client / persistence 四方共读，
     # 不再寄生在 inference_config.yaml 的 global 块里互相反向依赖）。env: CLEANSIGHT_RAW_FPS 等。
-    raw_fps: int = 30          # 原始视频帧率
-    inference_fps: int = 15    # 推理/输出帧率（HLS processed 打标、client 限流共用）；取 30 的整除值，
-                               # 最小间隔门可干净放行"每隔一帧"（30→20 是算法天花板，本就到不了）
-    ca_maxlen: int = 2700      # CA 队列最大长度（帧数）
-    ca_segment_len: int = 300  # HLS 段长度（帧数）
+    raw_fps: int = 30          # 生产者源：解码 CFR 帧率（decoder default_fps、HLS raw fallback 全派生自此）
+    inference_fps: int = 15    # 采样器：检测抽帧采样率——系统唯一 fps 旋钮（queues Bresenham 抽帧）。
+                               # 取 30 的整除值；不再被 HLS processed/client 限流/模型输入借用（各自派生/契约化）。
+    # CA 缓存/段长本是"时间概念"，以秒声明（时间为跨子系统货币）；帧数在各消费边界按 raw_fps 显式换算。
+    ca_maxlen_seconds: int = 90    # CA 队列缓存时长（秒）→ 帧数 = ×raw_fps
+    ca_segment_seconds: int = 10   # HLS 段时长（秒）→ 帧数 = ×raw_fps
 
     # MediaMTX 端口映射（内部拉流时绕过 RTSPProxy 直连 MediaMTX）
     mediamtx_proxy_port: int = 8004      # RTSPProxy 对外暴露端口

--- a/config/inference_config.yaml
+++ b/config/inference_config.yaml
@@ -80,6 +80,9 @@ stages:
         class: app.services.inference.workflows.clean.CleanOperator
         params:
           window_seconds: 10.0
+          # 模型契约帧率：入模前把 ~inference_fps 的窗口按 ts 重采样到此帧率再喂模型。
+          # 必须等于训练 fps（gru-final.pt 训练于 7.5fps）；配错不崩、静默降级（train/serve skew）。
+          model_input_fps: 7.5
           model_path: ${CLEANSIGHT_MODEL_PATH:./app/data}/gru-final.pt
           actions:
             0: idle

--- a/config/persistence_config.yaml
+++ b/config/persistence_config.yaml
@@ -13,10 +13,11 @@ storage:
 hls:
   workers: 2                      # HLS Worker数量
   queue_size: 100                 # HLS队列最大长度
-  segment_duration: 10            # 视频段时长（秒）
   sweep_interval_seconds: 1.0     # HLSSegmentSweeper 扫描间隔（秒）：周期从活跃 CQ 拉走攒满的整段落盘（PULL）
 
-  # 注意：帧率参数（raw_fps, processed_fps←inference_fps）从 app/settings.py 读取（单一真源）
+  # 注意：不配 segment_duration——分段由 CQ 帧数(settings.ca_segment_seconds)触发、每段时长由
+  #      写入侧 EXTINF 从帧 ts 自适应，回放侧也从 EXTINF 读。配时长是死值且会误导。
+  # 注意：帧率参数从 app/settings.py 读取（单一真源），HLS 段编码 fps 由 strategy 从帧 ts 反推
 
 # 告警持久化配置
 alarm:

--- a/config/stream_config.yaml
+++ b/config/stream_config.yaml
@@ -5,7 +5,8 @@ decoder:
   # FFmpeg解码器配置
   default_width: 640
   default_height: 480
-  default_fps: 30
+  # default_fps 不在此设置：解码 CFR = 生产者源，单一真源 settings.raw_fps（env CLEANSIGHT_RAW_FPS）。
+  # 在此写死会重造第二个独立 fps 源、与 settings 漂移。
   pix_fmt: "bgr24"
   chunk_read_size: 32768     # 每次读取字节数
 

--- a/docs/update/20260722_FPS_TIME_VS_FRAME_DECOUPLE.md
+++ b/docs/update/20260722_FPS_TIME_VS_FRAME_DECOUPLE.md
@@ -95,7 +95,7 @@
 ### 三个 SET 点（Group 1）
 
 1. **生产者单一真源**：解码 CFR 从 `settings.raw_fps` 经 `default_factory` 取值（[stream/config.py `DecoderConfig.default_fps`](../../app/services/stream/config.py)），删除 [stream_config.yaml](../../config/stream_config.yaml) 里写死的 `default_fps: 30`——消除「两个巧合相等的独立 30」。
-2. **`inference_fps` 收敛为唯一采样旋钮**：抽帧器（[queues.py Bresenham](../../app/services/client/queues.py)）不动，[settings.py:94](../../app/settings.py#L94) 注释重写为「检测抽帧采样率——系统唯一 fps 旋钮」，删「HLS processed 打标 / client 限流共用」。
+2. **`inference_fps` 收敛为唯一采样旋钮**：抽帧器（[queues.py Bresenham](../../app/services/client/queues.py)）不动，[settings.py:94](../../app/settings.py#L94) 注释重写为「检测抽帧采样率——系统唯一 fps 旋钮」，删「HLS processed 打标 / client 限流共用」。收敛后 `settings.inference_fps` 的功能消费者只剩两个合法项：**采样器本尊**（queues 抽帧）与 **viz poll 率**（[manager.py](../../app/services/inference/manager.py)→pool→worker，消费者继承采样流速率、渲染按 `inference.ts` 去重）。HLS processed 的 `processed_fps` 兜底原来也借用 `inference_fps`，一并断开——改读 [persistence/config.py `_PROCESSED_FPS_FALLBACK`](../../app/services/persistence/config.py) 通用编码常量（processed 段主用 `eff_fps` 从 ts 反推，此常量仅退化段兜底，与采样率无关）。
 3. **模型契约在 inference 侧声明**：`model_input_fps: 7.5` 落 [inference_config.yaml](../../config/inference_config.yaml) CleanOperator `params`（紧挨 `actions`/`objects`）。**决策修正**：原计划 4「下沉到产物元数据」被否——7.5 配错**不崩、静默降级**（≠ shape/key mismatch），按判据属「真配置」而非「契约副本」，故声明在 inference 配置、不动跨仓产物 schema。加载期 `None`/`≤0` 在 [TemporalOperator.__init__](../../app/services/inference/temporal/operator.py) 暴露信号。
 
 ### 消费者去 fps 化（Group 2）

--- a/docs/update/20260722_FPS_TIME_VS_FRAME_DECOUPLE.md
+++ b/docs/update/20260722_FPS_TIME_VS_FRAME_DECOUPLE.md
@@ -1,0 +1,123 @@
+# fps 解耦：时间为唯一货币，帧率只在「生产/采样」两点设定
+
+> **变更状态**：生效中（2026-07-22）　<!-- 判据已随实现落地；结构解耦行为不变，Group 4 模型重采样改行为待 A/B 验。见文末「落地详情」 -->
+> **知识库**：待沉淀
+>
+> 触发背景：排查「实时链路动作误分类」时，发现根因之一是训练 7.5fps / 推理 15fps 的 train/serve skew；顺藤摸出系统内 `inference_fps` 是个被多处误用的「上帝常量」。本篇把讨论收敛成一条可复用的评审判据。
+> 承接：不依赖任何前序重构；相关代码引用均指向真源。
+
+## 概述
+
+- **提出什么**：一条判断「fps/帧率该不该在这里出现」的统一判据——**时间是子系统之间唯一的量纲货币；帧率只在把连续世界离散化的两个点（解码、检测采样）上才是真决策，其余一切消费者都由帧时间戳驱动，不设 fps。**
+- **为什么提**：当前 `inference_fps` 被当作检测采样 / HLS processed 编码 / client 限流的共用常量，且时序模型输入节奏隐式等于它（15）而模型契约实为 7.5——一个数裹了多个正交决策，导致「动 fps 非无损」，且误检归因无法做隔离实验。
+- **影响面**：不改行为，先立判据。落地时涉及 [app/settings.py](../../app/settings.py)、检测采样、HLS 持久化、AI WS 推流、时序算子输入适配。
+
+## 病灶：一个 fps 冒充多条边界的换算因子
+
+系统里本就存在**两个合法量纲域**，病根在两者交界处的换算被隐式化、全局化、且换错：
+
+- **时间域**（有物理语义、跨子系统）：响应延迟、动作时长、缓存保留、回看窗口、告警门。都是关于真实世界的陈述，与 fps 无关。
+- **帧域**（离散表示细节、子系统内部）：GRU 输入序列、逐帧检测、HLS 段的帧数编码。
+
+**判据一句话**：有物理语义或跨子系统的量 → 必须用**秒**；只活在单个离散子系统内部的量 → 可用帧，但**进出该子系统必须过一道显式 fps 换算，且那个 fps 属于这条边界、不共享**。
+
+### 六个症状归一
+
+排查中出现的问题，在此判据下是同一个病：
+
+| 表层症状 | 真身（时间 vs 帧域） |
+|---------|--------------------|
+| fps skew（训 7.5 / 推 15） | 模型帧域(7.5)被焊到检测帧域(15)，中间**无换算**——两种不同 fps 的帧被当同一种 |
+| 缓存/段长会漂移 | 时间概念（90s）被**存成帧数**（`ca_maxlen=2700`），fps 一变即漂 |
+| `inference_fps` 上帝常量 | 用**一个 fps** 去换算**多条各有各 fps 的边界** |
+| 动 `inference_fps` 非无损 | 动一条边界的换算因子，连带改了其它几条边界 |
+| tick 率是唯一解耦好的 | 因为它本就是**时间量纲**（`tick_interval` 单位秒），偏偏是唯一做对的 |
+| 模型输入节奏是「契约」 | 它是模型帧域的私有 fps，属那条边界自己的换算常数，必须随产物走 |
+
+## 核心判据：生产者/采样器 才 set，消费者只读时间戳
+
+每一帧都带墙钟时间戳（pool 盖章、[hls_strategy `_effective_fps`](../../app/services/persistence/strategies/hls_strategy.py) 读它、clip_builder 用它）。**时间戳就是「何时」的唯一权威载体**，于是：
+
+| 角色 | 是否设 fps | 系统里是谁 | 驱动 |
+|------|:-:|-----------|------|
+| **生产者**（把流强加到世界上） | ✅ set | 解码器 30（`raw_fps`） | 源/带宽 |
+| **采样器**（改变流的密度） | ✅ set | 检测抽帧 30→15（`inference_fps`） | 感知/算力 |
+| **消费者**（转码/推送/回放） | ❌ 读 ts | processed HLS、AI WS、raw HLS | 无——继承流 |
+| **契约消费者**（有自己帧域的） | ❌ 读 ts + 重采样到契约 | 时序模型 → 7.5 | 产物契约 |
+
+**真正需要「设 fps」的只剩两处：解码器(30)与检测采样(15)。** 其余全是消费者，全该由时间戳驱动。给消费者显式设 fps，结果只有两种：与流一致（冗余）或与流不一致（bug 源）。
+
+### 系统内 fps 设定点现状
+
+| # | 子系统 | 现状 | 目标角色 | 备注 |
+|---|-------|------|---------|------|
+| 1 | 解码器 | `raw_fps=30` 固定，ffmpeg `fps=` 强制 | 🟢 生产者，保留 set | [settings.py:93](../../app/settings.py#L93)、[stream/config.py:24](../../app/services/stream/config.py#L24) |
+| 2 | 检测抽帧 | `inference_fps=15`（=raw×0.5） | 🟢 采样器，保留 set；**这是 `inference_fps` 唯一合法身份** | [settings.py:94](../../app/settings.py#L94) |
+| 3 | 时序模型输入 | **无显式设定**，隐式=15；契约实为 7.5 | 🔴 契约消费者：读 ts 重采样到 7.5，随产物走 | skew 的精确坐标——契约根本没被表达出来 |
+| 4 | 时序 tick | `tick_interval=1.0s` | ✅ 已对（时间域） | [actor.py:40](../../app/services/inference/temporal/actor.py#L40) |
+| 5 | HLS raw 段 | `raw_fps=30` 假定固定 | 🟠 消费者：应读 ts（潜伏同类 bug，raw 较稳未咬到） | [hls_strategy.py:38](../../app/services/persistence/strategies/hls_strategy.py#L38) |
+| 6 | HLS processed 段 | `eff_fps` 从 ts 反推 | ✅ 已对（时间域，正面样板） | [hls_strategy.py:592](../../app/services/persistence/strategies/hls_strategy.py#L592)；默认 `processed_fps=20` 已死、被覆盖 |
+| 7 | AI WS 推流 | 硬编码 `1/30` 轮询 | 🟠 消费者：改「有新 rendered 帧就推」，rate 白捡、不再重发 | 推的是 [`get_latest_rendered()`](../../app/routers/ai.py#L122)，即 rendered 流 |
+| 8 | 网关限流 | `rate_window=60s` 等 | ✅ 已对（时间域） | [settings.py:107](../../app/settings.py#L107) |
+
+### 关键洞察
+
+- **检测 / processed HLS / AI WS 不是三个 fps，是同一条 rendered 流的三个阶段**。收敛边界是「同一条流」，不是「都叫 fps」。正确统一是**共享来源 + 各自派生**（下游读流的实测速率），**不是共享一个字面量**——后者会重造小号上帝常量，并弄坏 processed 已修好的 `eff_fps` 抗漂移。
+- **系统里其实只有两条源流**：raw 流@30（未标注，给 raw HLS 与检测采样）、rendered 流@检测实测率（~11–15，给 processed HLS 与 AI live view）。「几个 fps」塌缩为：**1 个自由旋钮（检测采样）+ 1 个契约（模型 7.5）+ 2 条源流，其余全派生。**
+- **HLS processed 的 `_effective_fps` 是本课已学会的一半**：它因固定 fps 编码导致快放/抖动而改成「从墙钟反推」。修时序 skew、修 AI WS、修 HLS raw，都是**同一课在其它边界上再上一遍**。
+
+## 解耦不变式（评审 checklist）
+
+任何涉及帧率/时间的改动，逐条对照：
+
+1. **一轴一驱动**：每个轴只由自己的驱动决定，改一个不牵动其余。
+2. **契约钉死、随产物走**：模型输入节奏（7.5）来自产物元数据，不进部署配置；配错应在加载期以「契约不符」暴露，而非静默漂移。
+3. **检测密度 ⟂ 模型节奏**：两者间必须隔一层显式重采样。
+4. **时间概念用时间单位**：缓存/窗口/段长用秒，不用帧数。
+5. **消费者不设 fps**：转码/推送/回放一律读帧时间戳；见到消费者上有 fps 常量，即为耦合点。
+6. **裸 fps 常量被多处引用 = 危险信号**：多半在冒充多条边界的换算因子。
+
+## 解耦解锁的调试实验
+
+拆开耦合后，误检的每个假设才第一次可单独证伪（这是做本提案的初衷）：
+
+| 假设 | 现在为何验不了 | 解耦后单独拧哪个轴 |
+|------|--------------|-------------------|
+| 提检测密度能压漏检 | 一动 fps，模型 skew + HLS 同时变，被污染 | 只拧检测采样 |
+| fps skew 占误检多少 | skew 与检测密度绑死，分不开 | 只拧「模型节奏重采样」（对齐 7.5） |
+| 降响应延迟是否够 | ——（已可单独验，tick 独立） | 只拧 tick 率 |
+| 换因果模型净收益 | 前两项噪声未隔离，基线不干净 | 前三轴锁定后单换模型 |
+
+## 落地详情（2026-07-22）
+
+判据已随实现落地，一次性把三个 SET 点钉死、消费者改时间戳驱动、时间概念改秒。分组对照上表「系统内 fps 设定点现状」：
+
+### 三个 SET 点（Group 1）
+
+1. **生产者单一真源**：解码 CFR 从 `settings.raw_fps` 经 `default_factory` 取值（[stream/config.py `DecoderConfig.default_fps`](../../app/services/stream/config.py)），删除 [stream_config.yaml](../../config/stream_config.yaml) 里写死的 `default_fps: 30`——消除「两个巧合相等的独立 30」。
+2. **`inference_fps` 收敛为唯一采样旋钮**：抽帧器（[queues.py Bresenham](../../app/services/client/queues.py)）不动，[settings.py:94](../../app/settings.py#L94) 注释重写为「检测抽帧采样率——系统唯一 fps 旋钮」，删「HLS processed 打标 / client 限流共用」。
+3. **模型契约在 inference 侧声明**：`model_input_fps: 7.5` 落 [inference_config.yaml](../../config/inference_config.yaml) CleanOperator `params`（紧挨 `actions`/`objects`）。**决策修正**：原计划 4「下沉到产物元数据」被否——7.5 配错**不崩、静默降级**（≠ shape/key mismatch），按判据属「真配置」而非「契约副本」，故声明在 inference 配置、不动跨仓产物 schema。加载期 `None`/`≤0` 在 [TemporalOperator.__init__](../../app/services/inference/temporal/operator.py) 暴露信号。
+
+### 消费者去 fps 化（Group 2）
+
+4. **可视化 worker**：确认 15fps poll 是「消费者继承源流速率」的合法派生（渲染按 `inference.ts` 去重、组批推理产出即 15fps），**非上帝常量**，仅 [manager.py](../../app/services/inference/manager.py) 注释澄清、不改代码。
+5. **AI WS**：删 [ai.py](../../app/routers/ai.py) 的 `frame_interval=1.0/30` 伪 fps floor，主驱动改「新帧即推」（`frame.timestamp` 去重）；带宽上限保留为**模块内传输层常量** `_WS_MAX_SEND_FPS=30`（语义=传输节流、非管线 fps，**不进部署配置**——传输保护无需暴露成可调旋钮）。
+6. **HLS raw 段**：[hls_strategy.py `_persist_raw_segment`](../../app/services/persistence/strategies/hls_strategy.py) 的 VideoWriter + EXTINF 改用 `_effective_fps(frames, raw_fps)`（与 processed 段同款），`raw_fps` 降为 fallback。
+7. **clip_builder**：[clip_builder.py `_run_ffmpeg`](../../app/services/lab/clip_builder.py) 的 concat EXTINF 从固定 10s 改**逐段 ts 跨度**（末段用中位估算），消除 fps 漂移下 `-ss` seek 累计错位；窗口已过 `_validate_continuity` 保证相邻段连续。
+
+### 时间概念改秒（Group 3）
+
+8. `settings.ca_maxlen`/`ca_segment_len`（帧数）→ `ca_maxlen_seconds=90`/`ca_segment_seconds=10`（秒）；帧数在 [client/config.py](../../app/services/client/config.py) 属性按 `raw_fps` 显式换算（值仍 2700/300，**零行为变化**），删 [instance.py](../../app/services/inference/instance.py) 的帧→秒→帧往返。
+
+### 模型重采样（Group 4，唯一改行为）
+
+9. [TemporalOperator._resample_by_ts](../../app/services/inference/temporal/operator.py) + [CleanOperator._advance](../../app/services/inference/workflows/clean.py)：入模前按 `f.ts` **相位网格抽稀**到 `model_input_fps`（15fps 10s 窗口 150→75 帧；网格前进不累积漂移、遇缺口重锚不追补突发）。新帧门/`last_ts` 推进仍基于完整窗口，重采样只定喂模型的时间轴密度。
+
+**验证**：`pytest tests/` 335 passed；YAML→工厂装配确认 `model_input_fps=7.5` 贯通；结构解耦（1–3、5–8）行为不变。
+
+### 保留后续
+
+- **Group 4 单独 A/B 验**：取已知动作 clip，对比重采样前/后分类输出，量 train/serve skew 对误分类的占比（这是本次唯一改分类结果的改动）。
+- **新解锁实验**：解耦后可只拧检测采样率而不动模型节奏——降 `inference_fps` 省 GPU 等实验现可单独证伪（见上表「解耦解锁的调试实验」）。
+
+> 关联但正交的另一条线：实时误分类的架构性根因是**在线跑双向 BiGRU 并读最后时间步**（后向上下文为零），需换因果单向 GRU、BiGRU 冻为离线参考。那属模型侧改造，不在本篇 fps 解耦范围，另立记录。

--- a/docs/update/20260722_FPS_TIME_VS_FRAME_DECOUPLE.md
+++ b/docs/update/20260722_FPS_TIME_VS_FRAME_DECOUPLE.md
@@ -54,7 +54,7 @@
 | 1 | 解码器 | `raw_fps=30` 固定，ffmpeg `fps=` 强制 | 🟢 生产者，保留 set | [settings.py:93](../../app/settings.py#L93)、[stream/config.py:24](../../app/services/stream/config.py#L24) |
 | 2 | 检测抽帧 | `inference_fps=15`（=raw×0.5） | 🟢 采样器，保留 set；**这是 `inference_fps` 唯一合法身份** | [settings.py:94](../../app/settings.py#L94) |
 | 3 | 时序模型输入 | **无显式设定**，隐式=15；契约实为 7.5 | 🔴 契约消费者：读 ts 重采样到 7.5，随产物走 | skew 的精确坐标——契约根本没被表达出来 |
-| 4 | 时序 tick | `tick_interval=1.0s` | ✅ 已对（时间域） | [actor.py:40](../../app/services/inference/temporal/actor.py#L40) |
+| 4 | 时序 tick | `tick_interval=0.5s`（2Hz，2026-07-23 由 1.0s 上调，降告警上升沿延迟） | ✅ 已对（时间域） | [actor.py:40](../../app/services/inference/temporal/actor.py#L40) |
 | 5 | HLS raw 段 | `raw_fps=30` 假定固定 | 🟠 消费者：应读 ts（潜伏同类 bug，raw 较稳未咬到） | [hls_strategy.py:38](../../app/services/persistence/strategies/hls_strategy.py#L38) |
 | 6 | HLS processed 段 | `eff_fps` 从 ts 反推 | ✅ 已对（时间域，正面样板） | [hls_strategy.py:592](../../app/services/persistence/strategies/hls_strategy.py#L592)；默认 `processed_fps=20` 已死、被覆盖 |
 | 7 | AI WS 推流 | 硬编码 `1/30` 轮询 | 🟠 消费者：改「有新 rendered 帧就推」，rate 白捡、不再重发 | 推的是 [`get_latest_rendered()`](../../app/routers/ai.py#L122)，即 rendered 流 |

--- a/docs/update/20260723_CONFIG_LAYERING_FPS_TIME.md
+++ b/docs/update/20260723_CONFIG_LAYERING_FPS_TIME.md
@@ -1,0 +1,92 @@
+# 配置层级定型：settings 真旋钮 / yaml 编排契约 / 衍生量（帧率·时间）
+
+> **变更状态**：生效中（2026-07-23）　<!-- decimation 重构已落地，本篇把配置三层与"衍生量不进 yaml"不变式定型 -->
+> **知识库**：待沉淀
+>
+> 承接：建立在 [20260722_FPS_TIME_VS_FRAME_DECOUPLE.md](20260722_FPS_TIME_VS_FRAME_DECOUPLE.md)（时间为唯一货币、fps 只在两点设定）之上；本篇不重述判据，只给"落到哪一层"的当前定盘与配置分层规则。真源均指向代码。
+
+## 概述
+
+- **改了什么**：把 fps/时间相关配置归成**三层**并定死边界——settings 级只放**真旋钮**，yaml 级只放**编排 + 契约**，其余全是**衍生量**（活在代码属性、由 settings 算出）。采样旋钮由 `inference_fps` 改为整数 `inference_decimation`，`inference_fps` 降为派生 property。
+- **为什么改**：`inference_fps` 当过多处换算因子（上帝常量）；改造后必须有一份"谁在哪层、谁派生自谁"的定盘，否则衍生量迟早被人手滑写回 yaml、与 settings 漂移。
+- **影响面**：[app/settings.py](../../app/settings.py)、四个 config loader（stream/persistence/client/inference）、抽帧器 [queues.py](../../app/services/client/queues.py)、HLS strategy、viz pool。
+
+## 核心不变式（一句话判据）
+
+| 层 | 放什么 | 判据 | 铁律 |
+|----|--------|------|------|
+| **settings 级** | 跨模块单一真源的**真旋钮** + **时间概念** | 能自由调、调了行为变、不与另一产物强绑 | 整数 fps 旋钮只有 2 个 |
+| **yaml 级** | **编排**（选哪条 pipeline/哪个流）+ **契约**（随产物钉死的量） | 配错会崩（shape/key）或语义是"选择/契约" | 不含任何衍生量 |
+| **衍生量** | settings 算出的换算结果（代码属性） | 必须与真源严格一致、不能独立设 | **永不进 yaml**——进了就是第二真源 → 漂移 |
+
+## 一、settings 级（[app/settings.py](../../app/settings.py)）——真旋钮
+
+跨模块单一真源，env 可覆盖（`CLEANSIGHT_*`）。这一层**只有两个整数 fps 旋钮 + 两个时间概念**：
+
+| 字段 | 值/类型 | 角色 | env |
+|------|---------|------|-----|
+| `raw_fps` | 30 (int) | **生产者源**：解码 CFR 帧率 | `CLEANSIGHT_RAW_FPS` |
+| `inference_decimation` | 2 (int) | **采样器唯一旋钮**：抽帧"每 N 帧留 1" | `CLEANSIGHT_INFERENCE_DECIMATION` |
+| `ca_maxlen_seconds` | 90 (秒) | CA 缓存**时长**（时间货币，非帧数） | — |
+| `ca_segment_seconds` | 10 (秒) | HLS 段**时长**（时间货币，非帧数） | — |
+
+> 检测率 = `raw_fps / inference_decimation`。整数因子故**只能命中 raw_fps 的整除率**（30→15/10/7.5/6…，不支持 30→20 类非整除比）；非整除比的诉求由模型侧 `model_input_fps` 按 ts 重采样承接，不回退到这层放宽。
+
+## 二、yaml 级（[config/*.yaml](../../config/)）——编排 + 契约，零衍生量
+
+| 文件 | 留了什么 | 刻意不放 |
+|------|---------|---------|
+| [inference_config.yaml](../../config/inference_config.yaml) | `model_input_fps: 7.5`（**模型契约**，随产物钉死）、`window_seconds`（感受野） | 采样率/编码 fps |
+| [stream_config.yaml](../../config/stream_config.yaml) | `resize`、`backpressure` 等解码参数 | `default_fps`（已删，见衍生量④） |
+| [persistence_config.yaml](../../config/persistence_config.yaml) | `workers`、`queue_size`、`sweep_interval` | `segment_duration`、任何 fps（已删） |
+| [client_config.yaml](../../config/client_config.yaml) | `resize_width/height` | 队列长、fps |
+
+**关键状态：yaml 里"长得像 fps/时长"的量一个都不剩。** `model_input_fps` 是唯一的 fps，但它是契约不是旋钮——配错不崩、静默降级，故必填 + 加载期校验（见 [operator.py](../../app/services/inference/temporal/operator.py) `TemporalOperator.__init__`）。
+
+> **天然护栏**：四个 config loader 都是裸 `**dict`、不做字段过滤。谁往 yaml 误写一个衍生量（如 `raw_fps: 25`），构造即 `TypeError` **当场崩**，而非静默生效——与"响亮地崩"哲学一致，不需额外校验。
+
+## 三、衍生量（代码属性）——由 settings 算出，不可独立设
+
+| # | 衍生量 | 位置 | 公式 | 值 | 消费者 |
+|---|--------|------|------|----|--------|
+| ① | `settings.inference_fps` | [settings.py](../../app/settings.py) property | `raw_fps / inference_decimation` | 15.0 (float) | viz 轮询率 |
+| ② | `ClientConfig.ca_maxlen` | [client/config.py](../../app/services/client/config.py) | `ca_maxlen_seconds × raw_fps` | 2700 帧 | CQ 队列 |
+| ③ | `ClientConfig.ca_segment_len` | [client/config.py](../../app/services/client/config.py) | `ca_segment_seconds × raw_fps` | 300 帧 | CQ 分段（**唯一真源**） |
+| ④ | `DecoderConfig.default_fps` | [stream/config.py](../../app/services/stream/config.py) `default_factory` | `= settings.raw_fps` | 30 | ffmpeg `fps=` filter |
+| ⑤ | `VizWorkerPool.target_fps` | [manager.py](../../app/services/inference/manager.py) 注入 | `= settings.inference_fps` | 15 | tick=1/15，渲染按 ts 去重 |
+| ⑥ | `ClientQueues.inference_decimation` | [client/config.py](../../app/services/client/config.py) → cq_kwargs | 直读 `settings.inference_decimation` | 2 | 抽帧计数器 |
+
+> ① 派生化后**无从被设成与 `raw_fps/N` 不一致的值**（旧代码它是独立字段、能漂），这正是本次收敛的意义。
+> ⑤ 是"消费者继承源流速率"的合法派生——viz 消费的就是采样后 inference 流，poll 率跟随该流即可，非共用旋钮。
+
+## 四、运行时反推（不是配置——从帧 ts 现算）
+
+这些量既不在 settings 也不在 yaml，由数据现算，配置层完全不持：
+
+- **HLS 段编码 `eff_fps`** = `(N-1) / span`，raw/processed 段逐段各自反推（[hls_strategy.py](../../app/services/persistence/strategies/hls_strategy.py) `_effective_fps`）。VideoWriter 与 EXTINF 同源 → 回放对齐墙钟。
+- **WS 推帧率** = rendered 流实际到达率（"新帧即推"，按 `frame.timestamp` 去重，[ai.py](../../app/routers/ai.py)）。
+- **模型入模密度** = `_resample_by_ts` 按 ts 重采样到 `model_input_fps`（[operator.py](../../app/services/inference/temporal/operator.py)）。
+
+## 五、局部常量（模块私有——语义非管线 fps，故意不上升为配置）
+
+| 常量 | 位置 | 语义 |
+|------|------|------|
+| `_WS_MAX_SEND_FPS = 30` | [ai.py](../../app/routers/ai.py) | WS 传输带宽上限（传输保护，不进部署配置） |
+| `_DEGENERATE_FALLBACK_FPS = 15` | [hls_strategy.py](../../app/services/persistence/strategies/hls_strategy.py) | 退化段（单帧/span≤0/带外）兜底 EXTINF |
+| `_EFF_FPS_MIN=1 / _EFF_FPS_MAX=60` | 同上 | eff_fps 反推合理带 |
+
+> 这些与上游 fps 无关，就地取常量比引 settings 更诚实——它们回答的不是"流多快"，而是"传输别爆/退化段给个合理值"。
+
+## 改动详情（本次相对 20260722）
+
+1. **采样旋钮换根**：`settings.inference_fps`(15, 可设) → `inference_decimation`(2, 唯一旋钮)；`inference_fps` 改 property 派生。抽帧器 Bresenham 相位累加 → "每 N 帧留 1" 整数计数（CFR 已把时间烙成等距帧号，整数计数天然精确、无浮点累积）。见 [queues.py](../../app/services/client/queues.py) `append_ca_ready_with_throttle`。
+2. **client 去 fps**：`ClientConfig`/`ClientQueues` 的 `inference_fps`/`raw_fps` 参数 → `inference_decimation`；删 `client.inference_fps ↔ settings` 冲突检查（现单一真源、无从冲突）。
+3. **清死代码**：`InferenceManager` 的 `rt_fps`/`ca_segment_seconds` 参数 + `_ca_segment_len`（算出但全仓无人读）删除；[instance.py](../../app/services/inference/instance.py) 构造简化为 `InferenceManager()`。**CQ 段长单一真源明确落在衍生量③**，manager 的平行旧路消除。
+
+## 验证
+
+| 项 | 结果 |
+|----|------|
+| 全量 `pytest tests/` | 335 passed |
+| 抽帧率单测（整数计数） | 保留率精确 = 1/N |
+| yaml→工厂装配 | `model_input_fps=7.5` 贯通；无衍生量落 yaml |

--- a/tests/test_hls_eff_fps.py
+++ b/tests/test_hls_eff_fps.py
@@ -1,11 +1,15 @@
-"""Fix A：processed 段按实测 eff_fps 编码 —— HLSPersistenceStrategy._effective_fps 单测。
+"""Fix A：processed/raw 段按实测 eff_fps 编码 —— HLSPersistenceStrategy._effective_fps 单测。
 
 eff_fps = (N-1) / (ts_last - ts_first)；VideoWriter 与 EXTINF 同源，回放才对齐墙钟。
-覆盖：正常反推、span<=0 / 单帧回退、带外（异常时间戳）回退标称。
+覆盖：正常反推、span<=0 / 单帧回退、带外（异常时间戳）回退。反推是全程自适应、不引用任何
+上游 fps；无可测速率的退化段回退本地常量 `_DEGENERATE_FALLBACK_FPS`。
 """
 
 from factories import make_frame
-from app.services.persistence.strategies.hls_strategy import HLSPersistenceStrategy
+from app.services.persistence.strategies.hls_strategy import (
+    HLSPersistenceStrategy,
+    _DEGENERATE_FALLBACK_FPS,
+)
 
 
 def _frames(timestamps):
@@ -16,7 +20,7 @@ def test_effective_fps_normal():
     """300 帧均匀分布在 20s 跨度 → (300-1)/20 ≈ 14.95fps。"""
     n, span = 300, 20.0
     ts = [i * span / (n - 1) for i in range(n)]
-    eff = HLSPersistenceStrategy._effective_fps(_frames(ts), fallback=15.0)
+    eff = HLSPersistenceStrategy._effective_fps(_frames(ts))
     assert eff == (n - 1) / span
     # segment_duration 用同一 eff_fps → 等于真实墙钟跨度
     assert abs(n / eff - span * n / (n - 1)) < 1e-6
@@ -25,29 +29,29 @@ def test_effective_fps_normal():
 def test_effective_fps_matches_wallclock_round_trip():
     """eff_fps 编码 N 帧的媒体时长 ≈ 真实跨度（差一帧），逐段播成 1.0x。"""
     ts = [10.0 + i * 0.09 for i in range(101)]  # 101 帧、跨度 9.0s → ~11.1fps
-    eff = HLSPersistenceStrategy._effective_fps(_frames(ts), fallback=15.0)
+    eff = HLSPersistenceStrategy._effective_fps(_frames(ts))
     assert abs(eff - 100 / 9.0) < 1e-9
 
 
 def test_effective_fps_single_frame_falls_back():
-    eff = HLSPersistenceStrategy._effective_fps(_frames([5.0]), fallback=15.0)
-    assert eff == 15.0
+    eff = HLSPersistenceStrategy._effective_fps(_frames([5.0]))
+    assert eff == _DEGENERATE_FALLBACK_FPS
 
 
 def test_effective_fps_zero_span_falls_back():
-    """所有帧同一时间戳（span=0）→ 回退标称。"""
-    eff = HLSPersistenceStrategy._effective_fps(_frames([7.0, 7.0, 7.0]), fallback=15.0)
-    assert eff == 15.0
+    """所有帧同一时间戳（span=0）→ 回退退化兜底。"""
+    eff = HLSPersistenceStrategy._effective_fps(_frames([7.0, 7.0, 7.0]))
+    assert eff == _DEGENERATE_FALLBACK_FPS
 
 
 def test_effective_fps_out_of_band_falls_back():
-    """时间戳过于紧凑致反推值 > 60（异常）→ 回退标称，避免慢放。"""
+    """时间戳过于紧凑致反推值 > 60（异常）→ 回退退化兜底，避免慢放。"""
     ts = [0.0, 0.001, 0.002]  # (3-1)/0.002 = 1000fps，带外
-    eff = HLSPersistenceStrategy._effective_fps(_frames(ts), fallback=15.0)
-    assert eff == 15.0
+    eff = HLSPersistenceStrategy._effective_fps(_frames(ts))
+    assert eff == _DEGENERATE_FALLBACK_FPS
 
 
 def test_effective_fps_negative_span_falls_back():
-    """乱序时间戳致 span<0 → 回退标称。"""
-    eff = HLSPersistenceStrategy._effective_fps(_frames([10.0, 9.0]), fallback=15.0)
-    assert eff == 15.0
+    """乱序时间戳致 span<0 → 回退退化兜底。"""
+    eff = HLSPersistenceStrategy._effective_fps(_frames([10.0, 9.0]))
+    assert eff == _DEGENERATE_FALLBACK_FPS


### PR DESCRIPTION
1. 上帝常量 → 单一真源 + 派生
inference_fps 原本是被检测/编码/限流/模型输入多处借用的"上帝常量",动一处牵连全身。现在收敛成2 个真旋钮(生产 raw_fps、采样 inference_decimation),其余全部派生或从 ts 反推,且衍生量不进 yaml —— 从根上消除了"第二真源漂移"的可能。

2. 时间是跨子系统唯一货币
消费者(HLS 编码/WS 推流/回放/clip)一律读帧 ts、不设 fps，自适应帧率; 缓存/段长/窗口用秒声明。整条链抗 fps 漂移、回放自动对齐墙钟。

3. 契约显式化 + 加载期护栏
model_input_fps 从"隐式 = 检测率(埋着 train/serve skew)"变成显式必填契约,加载期做必填 + 上下界 + 浮点容差校验。把"shape-check 天生抓不到的静默错"(fps 改 T 不改 F)前移到启动即崩,配错无所遁形。

4. 正交解耦 → 可隔离实验
检测密度 / 模型节奏 / tick 频率 / 传输率四轴各自独立驱动,动一个不牵动其余。这才是真正解锁 —— 误检归因终于能做单变量实验(只拧检测密度、或只对齐模型 7.5),而不是一动 fps 全被污染。

5. 判据沉淀,防回归
把"谁该设 fps、谁是衍生量"的判据写进 temporal-review skill + 三层配置设计文档。下次接时序算子/改帧率,有 checklist 可依,不再重踩同一课。