### PR TITLE
HLS 段间时基错乱修复

### DIFF
--- a/app/routers/media.py
+++ b/app/routers/media.py
@@ -85,7 +85,7 @@ async def get_init(token: str = PathParam(..., description="media init segment t
         logger.info("[Media] Init token rejected: %s", e)
         raise HTTPException(status_code=403, detail="Invalid or expired token")
 
-    if payload.filename != "init.mp4":
+    if not payload.filename.endswith("init.mp4"):
         raise HTTPException(status_code=400, detail="Token does not point to init segment")
 
     path = _resolve_media_path(payload.task_id, payload.step_id, payload.filename)

--- a/app/routers/traceback.py
+++ b/app/routers/traceback.py
@@ -241,14 +241,14 @@ def _build_vod_playlist(
     - segs 经 playlist 过滤后为空（全部为在途段）→ 抛 404
     """
     task_dir = finder.task_dir(task_id, step_id)
-    init_path = task_dir / "init.mp4"
+    init_path = task_dir / f"{track}_init.mp4"
     if not init_path.exists():
         raise HTTPException(
             status_code=503,
             detail={
                 "error": "HLS init segment missing",
                 "detail": (
-                    f"init.mp4 not found for task {task_id} step {step_id}. "
+                    f"{track}_init.mp4 not found for task {task_id} step {step_id}. "
                     "Historical segments must be migrated via "
                     "scripts/transcode_segments_to_h264.py before HLS playback."
                 ),
@@ -271,7 +271,7 @@ def _build_vod_playlist(
 
     base_url = str(request.base_url).rstrip("/")
     init_token = MediaToken.default().sign(
-        task_id=task_id, step_id=step_id, filename="init.mp4", kind="init",
+        task_id=task_id, step_id=step_id, filename=f"{track}_init.mp4", kind="init",
     )
 
     lines: List[str] = [

--- a/app/services/lab/clip_builder.py
+++ b/app/services/lab/clip_builder.py
@@ -306,10 +306,11 @@ class ClipBuilder:
         end_s = offset_s + duration_s
 
         step_dir = segs[0].path.parent
-        init_path = step_dir / "init.mp4"
+        # 打点仅用 raw 轨的 init.mp4
+        init_path = step_dir / "raw_init.mp4"
         if not init_path.exists():
             raise ClipBuildError(
-                f"init.mp4 missing in step dir: {step_dir} "
+                f"raw_init.mp4 missing in step dir: {step_dir} "
                 f"(fMP4 fragment 段需要 EXT-X-MAP 才能解码)"
             )
 
@@ -332,7 +333,7 @@ class ClipBuilder:
             "#EXT-X-VERSION:7",
             "#EXT-X-PLAYLIST-TYPE:VOD",
             f"#EXT-X-TARGETDURATION:{int(target_dur_s) + 1}",
-            '#EXT-X-MAP:URI="init.mp4"',
+            '#EXT-X-MAP:URI="raw_init.mp4"',
         ]
         for s, dur_us in zip(segs, seg_durs_us):
             lines.append(f"#EXTINF:{dur_us / 1_000_000.0:.3f},")

--- a/app/services/lab/step_exporter.py
+++ b/app/services/lab/step_exporter.py
@@ -129,9 +129,9 @@ class StepExporter:
                 f"step_id={step_id} (all in-flight or playlist missing)"
             )
 
-        if not (step_dir / "init.mp4").exists():
+        if not (step_dir / f"{track}_init.mp4").exists():
             raise StepExportInitMissing(
-                f"init.mp4 not found for task {task_id} step {step_id}. "
+                f"{track}_init.mp4 not found for task {task_id} step {step_id}. "
                 "Historical segments must be migrated via "
                 "scripts/transcode_segments_to_h264.py before export."
             )
@@ -141,7 +141,7 @@ class StepExporter:
         output_path = self._temp_root / f"step_{task_id}_{step_id}_{track}_{nonce}.mp4"
 
         tmp_m3u8.write_text(
-            self._build_vod_text(segs, durations), encoding="utf-8"
+            self._build_vod_text(segs, durations, track), encoding="utf-8"
         )
         try:
             self._run_ffmpeg(tmp_m3u8, output_path, n_segments=len(segs))
@@ -164,7 +164,7 @@ class StepExporter:
     # -------- internal --------
 
     @staticmethod
-    def _build_vod_text(segs: List[SegmentRef], durations: dict) -> str:
+    def _build_vod_text(segs: List[SegmentRef], durations: dict, track: str) -> str:
         """构造喂给 ffmpeg 的 VOD m3u8 文本。
 
         段用 basename 引用 —— 该 m3u8 落在 step 目录，相对 URI 才解析得到
@@ -181,7 +181,7 @@ class StepExporter:
             "#EXT-X-PLAYLIST-TYPE:VOD",
             f"#EXT-X-TARGETDURATION:{target_duration}",
             "#EXT-X-MEDIA-SEQUENCE:0",
-            '#EXT-X-MAP:URI="init.mp4"',
+            f'#EXT-X-MAP:URI="{track}_init.mp4"',
         ]
         for s, dur in zip(segs, seg_durs):
             lines.append(f"#EXTINF:{dur:.3f},")

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -46,10 +46,11 @@ class HLSPersistenceStrategy:
         db_dir: Path,
     ):
         self.db_dir = db_dir
-        # HLS 段编码帧率全程从帧 ts 反推（见 _effective_fps），不接收任何上游 fps。
         # 按 target_dir 路径索引的细粒度锁，序列化同一任务目录下的 playlist/metadata 写操作
         self._dir_locks: Dict[str, threading.Lock] = {}
         self._dir_locks_guard = threading.Lock()
+        self.raw_fps = settings.raw_fps
+        self.processed_fps = settings.inference_fps
 
     @staticmethod
     def _effective_fps(frames: List[Frame]) -> float:
@@ -508,9 +509,8 @@ class HLSPersistenceStrategy:
 
         start_ts = frames[0].timestamp
 
-        # 1. 生成原始视频段：帧率从帧 ts 反推（与 processed 段同款），无可测速率时退化兜底。
-        # 解码 CFR 名义 30，但实际可漂移；用实测 eff_fps 让回放速率贴合真实墙钟。
-        eff_fps = self._effective_fps(frames)
+        # 1. 生成原始视频段（使用原始视频源帧率30fps）
+        eff_fps = self.raw_fps
         raw_segment_path = target_dir / f"raw_segment_{int(start_ts * 1e6)}.mp4"
         height, width = frames[0].frame.shape[:2]
         fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore[attr-defined]
@@ -603,9 +603,9 @@ class HLSPersistenceStrategy:
         # 逐段速率不同 → 段间忽快忽慢的抖动。逐段各取自身 eff_fps，VideoWriter 与 EXTINF
         # 同源 → 每段播成 1.0x，对齐墙钟、抖动消失。详见
         # docs/update/20260629_PROCESSED_PLAYBACK_RATE_PROPOSAL.md。
-        eff_fps = self._effective_fps(frames)
+        eff_fps = self.processed_fps
 
-        # 1. 生成处理后视频段（使用实测有效帧率 eff_fps）
+        # 1. 生成处理后视频段（使用处理后视频源帧率 processed_fps）
         segment_path = target_dir / f"processed_segment_{int(start_ts * 1e6)}.mp4"
         height, width = frames[0].frame.shape[:2]
         fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore[attr-defined]

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -245,7 +245,7 @@ class HLSPersistenceStrategy:
         return struct.unpack(">I", data[ts_off : ts_off + 4])[0]
 
     @classmethod
-    def _get_or_cache_timescale(cls, target_dir: Path) -> Optional[int]:
+    def _get_or_cache_timescale(cls, target_dir: Path, segment_type: str) -> Optional[int]:
         """读取 step dir 的 timescale；优先用 `.hls_timescale` 缓存文件，否则解析 init.mp4 并写缓存。
 
         缓存文件单行十进制整数。解析失败 / init.mp4 缺失返回 None。
@@ -258,7 +258,7 @@ class HLSPersistenceStrategy:
                     return int(txt)
             except OSError:
                 pass
-        init_path = target_dir / "init.mp4"
+        init_path = target_dir / f"{segment_type}_init.mp4"
         if not init_path.exists():
             return None
         ts = cls._read_timescale_from_init(init_path)
@@ -324,7 +324,7 @@ class HLSPersistenceStrategy:
         return True
 
     @classmethod
-    def _transcode_to_fmp4_segment(cls, path: Path) -> None:
+    def _transcode_to_fmp4_segment(cls, path: Path, segment_type: str) -> None:
         """将 cv2 写出的 mp4v 段转码为 HLS-ready fMP4 fragment，并写入 step 级 init.mp4。
 
         Pipeline：cv2 mp4v → ffmpeg HLS muxer → init.mp4（首段）+ fMP4 fragment（原地替换）
@@ -347,7 +347,7 @@ class HLSPersistenceStrategy:
         失败时保留 mp4v 原文件并打 warning，不抛异常 —— 主流程可用性优先。
         """
         target_dir = path.parent
-        init_path = target_dir / "init.mp4"
+        init_path = target_dir / f"{segment_type}_init.mp4"
         ts_offset = cls._ts_offset_seconds(path)
 
         stem = path.stem
@@ -377,7 +377,7 @@ class HLSPersistenceStrategy:
             settings.ffmpeg_path,
             "-y",
             "-loglevel", "error",
-            "-i", str(path),  # 输入保留绝对路径，与 cwd 无关
+            "-i", str(path.resolve()),  # 输入保留绝对路径，与 cwd 无关
             "-c:v", "libx264",
             "-preset", "veryfast",
             "-crf", "23",
@@ -447,7 +447,7 @@ class HLSPersistenceStrategy:
         # hex-patch tfdt：把累计 EXTINF（秒）→ timescale tick 写进 fragment 的 moof/traf/tfdt
         # 没有 init.mp4 / timescale 读不到 → 跳过 patch，不影响首段（offset=0 本就正确）
         if replaced and ts_offset > 0.0:
-            timescale = cls._get_or_cache_timescale(target_dir)
+            timescale = cls._get_or_cache_timescale(target_dir, segment_type)
             if timescale and timescale > 0:
                 cls._patch_fragment_tfdt(path, int(round(ts_offset * timescale)))
             else:
@@ -549,9 +549,9 @@ class HLSPersistenceStrategy:
                             "#EXTM3U\n"
                             "#EXT-X-VERSION:7\n"
                             "#EXT-X-TARGETDURATION:10\n"
-                            '#EXT-X-MAP:URI="init.mp4"\n'
+                            '#EXT-X-MAP:URI="raw_init.mp4"\n'
                         )
-                self._transcode_to_fmp4_segment(raw_segment_path)
+                self._transcode_to_fmp4_segment(raw_segment_path, "raw")
                 with raw_playlist_path.open("a") as f:
                     f.write(f"#EXTINF:{segment_duration:.3f},\n{raw_segment_path.name}\n")
             except IOError as e:
@@ -643,9 +643,9 @@ class HLSPersistenceStrategy:
                             "#EXTM3U\n"
                             "#EXT-X-VERSION:7\n"
                             "#EXT-X-TARGETDURATION:10\n"
-                            '#EXT-X-MAP:URI="init.mp4"\n'
+                            '#EXT-X-MAP:URI="processed_init.mp4"\n'
                         )
-                self._transcode_to_fmp4_segment(segment_path)
+                self._transcode_to_fmp4_segment(segment_path, "processed")
                 with playlist_path.open("a") as f:
                     f.write(f"#EXTINF:{segment_duration:.3f},\n{segment_path.name}\n")
             except IOError as e:

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -598,11 +598,9 @@ class HLSPersistenceStrategy:
 
         start_ts = frames[0].timestamp
 
-        # 0. 按本段帧时间戳跨度反推有效 fps：processed 实际成帧率随 throttle / 渲染尖峰
-        # 在窗口间漂移（~11-15fps），固定名义帧率编码会按 兜底/真实率 倍快放，且
-        # 逐段速率不同 → 段间忽快忽慢的抖动。逐段各取自身 eff_fps，VideoWriter 与 EXTINF
-        # 同源 → 每段播成 1.0x，对齐墙钟、抖动消失。详见
-        # docs/update/20260629_PROCESSED_PLAYBACK_RATE_PROPOSAL.md。
+        # 固定 processed_fps 编码，不按本段帧 ts 反推。逐段 eff_fps 会破坏 HLS fMP4
+        # timescale 一致性 → SourceBuffer gap → 段尾停摆；代价是回放速率随实测率
+        # （~11-15fps）漂移，视觉上略抖动，但不卡死。详见 docs/update/20260817_HLS_DUAL_TRACK_FIXED_FPS.md。
         eff_fps = self.processed_fps
 
         # 1. 生成处理后视频段（使用处理后视频源帧率 processed_fps）

--- a/docs/update/20260817_HLS_DUAL_TRACK_FIXED_FPS.md
+++ b/docs/update/20260817_HLS_DUAL_TRACK_FIXED_FPS.md
@@ -1,0 +1,68 @@
+# HLS 双轨固定帧率：raw / processed 各自 init.mp4 + 编码 fps 不再反推
+
+> **变更状态**：生效中（2026-08-17）
+> **知识库**：待沉淀
+>
+> 承接：[20260722_FPS_TIME_VS_FRAME_DECOUPLE](20260722_FPS_TIME_VS_FRAME_DECOUPLE.md) 的「时间是唯一货币」判据。那次把 raw 段也改成读 `_effective_fps(frames)`，本篇回退为固定 `raw_fps`，并补上漏掉的「双轨 init.mp4」。
+
+## 概述
+
+- **改了什么**：HLS raw / processed 段的编码 fps 不再从帧时间戳反推，分别固定为 `settings.raw_fps` 与 `settings.inference_fps`；同一 step 目录下两条轨各自维护 `raw_init.mp4` / `processed_init.mp4`，不再共用 `init.mp4`。
+- **为什么改**：`Frame.timestamp` 取自 [decoder.py `time.time()`](../../app/services/stream/decoder.py)，虽约定当作墙钟、却混入解码抖动与背压等待，直接参与 fps 运算会污染回放速率；更致命的是逐段不同的 fps 会破坏 HLS fMP4 的 timescale 一致性。
+- **影响面**：[hls_strategy.py](../../app/services/persistence/strategies/hls_strategy.py)、[media.py](../../app/routers/media.py)、[traceback.py](../../app/routers/traceback.py)、[clip_builder.py](../../app/services/lab/clip_builder.py)、[step_exporter.py](../../app/services/lab/step_exporter.py) 及对应测试。
+
+
+## 动机
+
+### 1. `Frame.timestamp` 不是真墙钟
+
+[decoder.py `_process_frames`](../../app/services/stream/decoder.py) 给每帧盖 `time.time()`——这是 Python 解码线程收 chunk 时的本地墙钟，夹带 ffmpeg RTSP 缓冲、`-vsync drop` 丢帧、背压等待、GIL 调度等噪声。系统约定把它当作墙钟（用于去重、`tfdt` 偏移、段连续性判据足够），但**不应直接参与 fps 反推**：`(N-1)/(ts_last-ts_first)` 把噪声当作源速率，解码线程被抢占多就慢放、丢帧时 ts 间隔没同步缩小就快放。
+
+### 2. 即使 fps 算对了，逐段不同也会让 HLS 卡死
+
+HLS fMP4 的 `EXT-X-MAP`（init.mp4）是整 playlist 共用的「解码器配置 + 时间基准」，里面固化了 `mdhd` 的 **timescale** 与 SPS/PPS。本系统 [_transcode_to_fmp4_segment](../../app/services/persistence/strategies/hls_strategy.py) 只在首段生成 init.mp4、后续段复用——也就是整 playlist 的时间基准被首段钉死。若每段用不同 `eff_fps` 编码：cv2 写出的 mp4v 内部 timescale 与帧间隔各异，ffmpeg 转码到 fMP4 时后续段的时间戳要往首段 timescale 上凑，逐段量化误差累积 → fragment 的 `tfdt`/`trun` duration 与 playlist 声明的 `#EXTINF` 不严格匹配 → hls.js 通过 MSE（Media Source Extensions，浏览器给 `<video>` 流式 append 媒体片段的 API）把 fragment 顺序喂进 SourceBuffer 时，相邻段时间戳不首尾相接 → 出现 buffer gap → 段尾停摆、播放卡死。
+
+**结论**：HLS 编码 fps 必须全 playlist 统一并与 init.mp4 同源，固定值是唯一解。
+
+### 3. raw 与 processed 是两条不同速率的流，必然要两份 init.mp4
+
+raw@30 与 processed@15 各有 playlist，timescale 应分别来自 `raw_init.mp4` / `processed_init.mp4`。旧代码两条 playlist 都写 `#EXT-X-MAP:URI="init.mp4"`，transcode 不分轨——**谁先到谁生成**，第二条轨就指向一个 timescale 不匹配的 init.mp4，直接触发 §2。
+
+## 改动详情
+
+### 1. [hls_strategy.py](../../app/services/persistence/strategies/hls_strategy.py)
+
+- `__init__` 增加 `self.raw_fps = settings.raw_fps` / `self.processed_fps = settings.inference_fps`，删除「全程从 ts 反推」的注释。
+- `_persist_raw_segment` / `_persist_processed_segment`：`eff_fps` 从 `self._effective_fps(frames)` 改为 `self.raw_fps` / `self.processed_fps`。
+- playlist 头与 transcode 调用按轨区分：raw 段写 `raw_init.mp4`、调 `_transcode_to_fmp4_segment(path, "raw")`；processed 段同款。
+- `_get_or_cache_timescale(target_dir, segment_type)` / `_transcode_to_fmp4_segment(path, segment_type)`：`init_path` 改 `f"{segment_type}_init.mp4"`；顺带把 ffmpeg `-i` 改 `str(path.resolve())`，消除 cwd 隐式依赖。
+- [`_effective_fps`](../../app/services/persistence/strategies/hls_strategy.py) 函数体与上下文常量**保留未删**，已无调用点，留单独清理。
+
+### 2. [media.py](../../app/routers/media.py) — init 路由白名单
+
+token 校验从字面量 `init.mp4` 放宽到「以 `init.mp4` 结尾」，两类 init 都能走该路由取段。
+
+### 3. [traceback.py](../../app/routers/traceback.py) `_build_vod_playlist`
+
+按 `track` 参数构造 init 路径与 token filename，原硬编码 `init.mp4` 替换为 `f"{track}_init.mp4"`。
+
+### 4. [clip_builder.py](../../app/services/lab/clip_builder.py)
+
+打点拼接只用 raw 段，固定指向 `raw_init.mp4`（路径校验 + `#EXT-X-MAP` URI）。
+
+### 5. [step_exporter.py](../../app/services/lab/step_exporter.py)
+
+`_build_vod_text` 加 `track` 参数透传到 `EXT-X-MAP` URI；`_export_step` 先校验 `step_dir / f"{track}_init.mp4"` 存在再拼 m3u8。
+
+### 6. 测试
+
+`test_lab_clip_builder.py`、`test_lab_step_exporter.py`、`test_traceback_router.py` 中所有 `init.mp4` 字面量按上下文替换为 `raw_init.mp4` / `processed_init.mp4`；`_seed_task` 同时 seed 两份 init。
+
+## 未处理：丢帧静默不补偿
+
+ffmpeg `-vsync drop` 与解码侧背压丢帧当前**全部静默接受**，raw 段按固定 `raw_fps` 编码：段内实际帧数 N < `raw_fps × 墙钟时长` → 段媒体时长 = `N/raw_fps` < 真实墙钟，丢帧导致的「时间压缩」直接落到回放（10s 真实段可能只播 8s）。
+
+EXTINF 与 fragment 实际时长仍一致（都用 `N/raw_fps`），**不会触发 §2 的卡顿**，只是回放比真实时间快。`frames_dropped` 与 `frame_drop_total.labels(reason="ingress_backpressure")` 仅做 metrics 计数，满了就 dump、不补帧。
+
+不修的原因：补帧要么黑帧填充，要么改回 wall-clock EXTINF（回到 §2 错位）。正确方向是改 `Frame.timestamp` 来源用 ffmpeg PTS，属解码层改造，不在本篇范围。
+

--- a/tests/test_lab_clip_builder.py
+++ b/tests/test_lab_clip_builder.py
@@ -40,7 +40,7 @@ def _make_step_with_segments(
     for ts in segs_ts_us:
         (step_dir / f"raw_segment_{ts}.mp4").write_bytes(b"fake-fmp4")
     if with_init:
-        (step_dir / "init.mp4").write_bytes(b"fake-init")
+        (step_dir / "raw_init.mp4").write_bytes(b"fake-init")
     return step_dir
 
 
@@ -106,7 +106,7 @@ class TestRunFfmpegM3u8:
         text = captured["m3u8_text"]
         assert "#EXTM3U" in text
         assert "#EXT-X-VERSION:7" in text
-        assert '#EXT-X-MAP:URI="init.mp4"' in text
+        assert '#EXT-X-MAP:URI="raw_init.mp4"' in text
         # 段以 basename 出现（相对 URI，依赖临时 m3u8 与段同目录）
         assert f"raw_segment_{ts0}.mp4" in text
         assert f"raw_segment_{ts1}.mp4" in text

--- a/tests/test_lab_step_exporter.py
+++ b/tests/test_lab_step_exporter.py
@@ -58,7 +58,7 @@ def _make_step(
     for ts in segs_ts_us:
         (step_dir / f"{track}_segment_{ts}.mp4").write_bytes(b"fake-fmp4")
     if with_init:
-        (step_dir / "init.mp4").write_bytes(b"fake-init")
+        (step_dir / f"{track}_init.mp4").write_bytes(b"fake-init")
 
     in_playlist = segs_ts_us if playlist_ts is None else playlist_ts
     durs = durations or [10.0] * len(in_playlist)
@@ -66,7 +66,7 @@ def _make_step(
         "#EXTM3U",
         "#EXT-X-VERSION:7",
         "#EXT-X-TARGETDURATION:10",
-        '#EXT-X-MAP:URI="init.mp4"',
+        f"#EXT-X-MAP:URI={track}_init.mp4",
     ]
     for ts, d in zip(in_playlist, durs):
         lines.append(f"#EXTINF:{d:.3f},")
@@ -127,7 +127,7 @@ class TestVodPlaylist:
         assert "#EXTM3U" in text
         assert "#EXT-X-VERSION:7" in text
         assert "#EXT-X-PLAYLIST-TYPE:VOD" in text
-        assert '#EXT-X-MAP:URI="init.mp4"' in text
+        assert '#EXT-X-MAP:URI="raw_init.mp4"' in text
         # 段以 basename 出现（相对 URI，依赖临时 m3u8 与段同目录）
         assert f"raw_segment_{TS0}.mp4" in text
         assert f"raw_segment_{TS1}.mp4" in text

--- a/tests/test_traceback_router.py
+++ b/tests/test_traceback_router.py
@@ -35,11 +35,11 @@ def _seed_task(base_dir: Path, task_id: int, step_id: int, ts_us_list, write_ini
     d.mkdir(parents=True, exist_ok=True)
     raw_pl_lines = [
         "#EXTM3U", "#EXT-X-VERSION:7", "#EXT-X-TARGETDURATION:10",
-        '#EXT-X-MAP:URI="init.mp4"',
+        '#EXT-X-MAP:URI="raw_init.mp4"',
     ]
     proc_pl_lines = [
         "#EXTM3U", "#EXT-X-VERSION:7", "#EXT-X-TARGETDURATION:10",
-        '#EXT-X-MAP:URI="init.mp4"',
+        '#EXT-X-MAP:URI="processed_init.mp4"',
     ]
     for ts_us in ts_us_list:
         (d / f"raw_segment_{ts_us}.mp4").write_bytes(b"\x00" * 16)
@@ -51,7 +51,8 @@ def _seed_task(base_dir: Path, task_id: int, step_id: int, ts_us_list, write_ini
     (d / "raw_playlist.m3u8").write_text("\n".join(raw_pl_lines) + "\n")
     (d / "processed_playlist.m3u8").write_text("\n".join(proc_pl_lines) + "\n")
     if write_init:
-        (d / "init.mp4").write_bytes(b"\x00" * 8)
+        (d / "raw_init.mp4").write_bytes(b"\x00" * 8)
+        (d / "processed_init.mp4").write_bytes(b"\x00" * 8)
     return d
 
 
@@ -440,10 +441,10 @@ async def test_media_segment_missing_file_returns_404(client, media_root):
 @pytest.mark.asyncio
 async def test_media_init_with_valid_token(client, media_root):
     d = _seed_task(media_root, task_id=10, step_id=1, ts_us_list=[1_000_000])
-    expected = (d / "init.mp4").read_bytes()
+    expected = (d / "raw_init.mp4").read_bytes()
 
     token = MediaToken.default().sign(
-        task_id=10, step_id=1, filename="init.mp4", kind="init",
+        task_id=10, step_id=1, filename="raw_init.mp4", kind="init",
     )
     resp = await client.get(f"/media/init/{token}")
     assert resp.status_code == 200


### PR DESCRIPTION
#### 变更概述

本次 PR 修改了当前 HLS 存储策略，HLS raw / processed 段的编码 fps 不再从帧时间戳反推，分别固定为 `settings.raw_fps` 与 `settings.inference_fps`；同一 step 目录下两条轨各自维护 `raw_init.mp4` / `processed_init.mp4`，不再共用 `init.mp4`。


#### 变更内容

+ `app/services/persistence/strategies/hls_strategy.py`： HLS raw / processed 段的编码 fps 分别固定为 `settings.raw_fps` 与 `settings.inference_fps`
+ `app/routers/media.py`, `app/routers/traceback.py`, `app/services/lab/clip_builder.py`, `app/services/lab/step_exporter.py`：修改 `init.mp4` 为 `{track}_init.mp4`
+ `tests/test_lab_clip_builder.py`, `tests/test_lab_step_exporter.py`, `tests/test_traceback_router.py`：修改 `init.mp4` 为 `{track}_init.mp4`

#### 自测情况

`python -m pytest tests/` 测试全部通过

本地读取 raw@30 和 processed@15（抽帧实现）的视频流后调用 `HLSPersistenceStrategy` 的 `persist_segment` 方法保存，并通过 hls.js 渲染到页面，可以得到时长相同的两段视频，且播放连贯无卡顿