### PR TITLE
HLS 段间时基错乱修复 + 离线推理原始帧查询功能支持

### DIFF
--- a/app/routers/media.py
+++ b/app/routers/media.py
@@ -85,7 +85,7 @@ async def get_init(token: str = PathParam(..., description="media init segment t
         logger.info("[Media] Init token rejected: %s", e)
         raise HTTPException(status_code=403, detail="Invalid or expired token")
 
-    if payload.filename != "init.mp4":
+    if not payload.filename.endswith("init.mp4"):
         raise HTTPException(status_code=400, detail="Token does not point to init segment")
 
     path = _resolve_media_path(payload.task_id, payload.step_id, payload.filename)

--- a/app/routers/traceback.py
+++ b/app/routers/traceback.py
@@ -241,14 +241,14 @@ def _build_vod_playlist(
     - segs 经 playlist 过滤后为空（全部为在途段）→ 抛 404
     """
     task_dir = finder.task_dir(task_id, step_id)
-    init_path = task_dir / "init.mp4"
+    init_path = task_dir / f"{track}_init.mp4"
     if not init_path.exists():
         raise HTTPException(
             status_code=503,
             detail={
                 "error": "HLS init segment missing",
                 "detail": (
-                    f"init.mp4 not found for task {task_id} step {step_id}. "
+                    f"{track}_init.mp4 not found for task {task_id} step {step_id}. "
                     "Historical segments must be migrated via "
                     "scripts/transcode_segments_to_h264.py before HLS playback."
                 ),
@@ -271,7 +271,7 @@ def _build_vod_playlist(
 
     base_url = str(request.base_url).rstrip("/")
     init_token = MediaToken.default().sign(
-        task_id=task_id, step_id=step_id, filename="init.mp4", kind="init",
+        task_id=task_id, step_id=step_id, filename=f"{track}_init.mp4", kind="init",
     )
 
     lines: List[str] = [

--- a/app/services/inference/offline/frame_tracker.py
+++ b/app/services/inference/offline/frame_tracker.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Optional, Iterator
+from collections import OrderedDict
+
+import numpy as np
+
+from app.domain.frame import Frame
+
+# fMP4 媒体时间基，与 hls_strategy.py 的 _HLS_TIMESCALE 必须同值同源。
+# tick = (ts - first_ts) * _HLS_TIMESCALE — 这里算的 tick 与 _update_timeline 写入
+# .timeline.idx 的 tick 是同一个量，故 timeline 索引能正确反查 frame_num。
+# 详见 hls_strategy.py 该常量注释（为什么 pin 90000、为什么不随 fps 变）。
+_HLS_TIMESCALE = 90000
+
+
+class Timeline:
+    """时间线：维护 ts → frame_num 的映射关系。
+
+    读 hls_strategy._update_timeline 产出的 .timeline.idx（二进制 numpy structured array，
+    dtype=[("tick", uint64)]，每帧一条 tick 记录，按 raw 段落盘顺序追加）。
+    建立 tick → frame_num（0-based，全局递增）的反查字典，frame_num 即该帧在整条
+    raw_playlist 中的全局序号。查询时把 ts 转成 tick 直接查表。
+    """
+
+    def __init__(self, task_dir: Path):
+        self._first_ts = self._get_first_ts(task_dir)
+        data = self._load_from_file(task_dir)
+        self._frame_nums = {tick: i for i, tick in enumerate(data["tick"])}
+
+    def _get_first_ts(self, task_dir: Path) -> float:
+        metadata_path = task_dir / "metadata.json"
+        with open(metadata_path, "r") as f:
+            return json.load(f)["raw_segments"]["first_timestamp"]
+
+    def _load_from_file(self, task_dir: Path) -> np.ndarray:
+        return np.fromfile(
+            task_dir / ".timeline.idx",
+            dtype=np.dtype([("tick", np.uint64)]),
+        )
+
+    def frame_num_at(self, ts: float) -> int:
+        # tick 公式与 hls_strategy._update_timeline 完全一致，保证查表命中。
+        tick = int((ts - self._first_ts) * _HLS_TIMESCALE)
+        return self._frame_nums[tick]
+
+
+class FrameCache:
+    """帧缓存：维护 frame_num → frame 的映射关系。
+
+    用 ffmpeg 从 raw_playlist.m3u8 按 frame_num 范围提取帧（select=between），
+    按 block_size 分块缓存（LRU），避免逐帧 seek 的 ffmpeg 启动开销。
+
+    """
+    def __init__(
+        self,
+        task_dir: Path,
+        capacity: int = 10,
+        block_size: int = 600,
+        ffmpeg_bin: Optional[str] = None,
+    ):
+        """初始化帧缓存
+
+        task_dir: 任务目录，包含 raw_playlist.m3u8 和 metadata.json。
+        capacity: 缓存块最大数量。
+        block_size: 每个缓存块的帧数。
+        """
+        self._capacity = capacity
+        self._block_size = block_size
+        self._cache: OrderedDict[int, np.ndarray] = OrderedDict()
+
+        self._task_dir = task_dir
+        self._timeline = Timeline(task_dir)
+
+        if ffmpeg_bin is None:
+            from app.settings import settings
+            ffmpeg_bin = settings.ffmpeg_path
+        self._ffmpeg = ffmpeg_bin
+
+    def frame_at(self, ts: float, width: int, height: int) -> np.ndarray:
+        """根据 ts 提取 frame_num 对应的 frame。
+        缓存命中时直接返回，否则从 raw_playlist.m3u8 提取并缓存。
+
+        ts: 时间戳，单位秒。
+        width: 目标帧宽度。
+        height: 目标帧高度。
+
+        返回：
+        np.ndarray: 目标帧数据，形状为 (height, width, 3)。
+        """
+        frame_num = self._timeline.frame_num_at(ts)
+        idx, offset = divmod(frame_num, self._block_size)
+        block = self._cache.get(idx)
+        if block is None:
+            block = self._load_block(idx, width, height)
+        self._update_cache(idx, block)
+        return block[offset]
+
+    def _update_cache(self, block_id: int, block: np.ndarray):
+        # LRU cache
+        if block_id in self._cache:
+            self._cache.move_to_end(block_id)
+        else:
+            if len(self._cache) >= self._capacity:
+                self._cache.popitem(last=False)
+        self._cache[block_id] = block
+
+    def _load_block(self, block_id: int, width: int, height: int) -> np.ndarray:
+        """
+        加载第 block_id 个数据块，每个块包含 block_size 帧。
+        ffmpeg between 左右均为闭区间。
+        """
+        start = block_id * self._block_size
+        end = start + self._block_size - 1
+        return self._extract_frames(start, end, width, height)
+
+    def _extract_frames(self, start: int, end: int, width: int, height: int) -> np.ndarray:
+        # 用 ffmpeg select=between(n) 从 raw_playlist 按全局帧号范围提取，
+        # 输出 rawvideo bgr24 到 pipe。-vsync 0 禁用丢帧/重复帧，保证 count 精确。
+        m3u8 = self._task_dir / "raw_playlist.m3u8"
+        count = end - start + 1
+        frame_size = width * height * 3
+
+        cmd = [
+            self._ffmpeg,
+            "-i", m3u8.as_posix(),
+            "-vf", f"select=between(n\\,{start}\\,{end})",
+            "-vframes", str(count),
+            "-vsync", "0",
+            "-f", "rawvideo",
+            "-pix_fmt", "bgr24",
+            "pipe:1",
+        ]
+
+        pipe = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=frame_size * 8,
+        )
+
+        frames = []
+        try:
+            while len(frames) < count:
+                chunk = pipe.stdout.read(frame_size)
+                if not chunk:
+                    break
+                if len(chunk) != frame_size:
+                    raise RuntimeError("Incomplete frame from FFmpeg")
+                frames.append(chunk)
+        except Exception as e:
+            pipe.kill()
+            raise RuntimeError(f"FFmpeg decode error: {e}") from e
+
+        stderr = pipe.stderr.read()
+        ret = pipe.wait()
+        if ret != 0:
+            raise RuntimeError(f"FFmpeg failed (code {ret}): {stderr.decode(errors='ignore')}")
+
+        # 若读取到视频末尾，会比 count 少一些帧，此处不做严格校验。
+        raw = b"".join(frames)
+        return np.frombuffer(raw, np.uint8).reshape(-1, height, width, 3)
+
+class FrameTracker:
+    """离线推理帧回看：给定 features.jsonl 内的记录，逐帧从 HLS 落盘段提取原始帧。
+    记录示例：
+    {"ts": 1785982791.9397182, "features": {...}, "frame_width": 640, "frame_height": 480}
+    
+    Pipeline: ts → Timeline.frame_num_at → FrameCache.frame_at（LRU + ffmpeg select）→ Frame。
+    """
+    def __init__(self, task_dir: Path, capacity: int = 10, block_size: int = 600):
+        self._cache = FrameCache(task_dir, capacity, block_size)
+
+    def find(self, records: list[dict]) -> Iterator[Frame]:
+        for record in records:
+            ts = float(record["ts"])
+            width, height = int(record["frame_width"]), int(record["frame_height"])
+            frame = self._cache.frame_at(ts=ts, width=width, height=height)
+            yield Frame(timestamp=ts, frame=frame)

--- a/app/services/lab/clip_builder.py
+++ b/app/services/lab/clip_builder.py
@@ -306,10 +306,11 @@ class ClipBuilder:
         end_s = offset_s + duration_s
 
         step_dir = segs[0].path.parent
-        init_path = step_dir / "init.mp4"
+        # 打点仅用 raw 轨的 init.mp4
+        init_path = step_dir / "raw_init.mp4"
         if not init_path.exists():
             raise ClipBuildError(
-                f"init.mp4 missing in step dir: {step_dir} "
+                f"raw_init.mp4 missing in step dir: {step_dir} "
                 f"(fMP4 fragment 段需要 EXT-X-MAP 才能解码)"
             )
 
@@ -332,7 +333,7 @@ class ClipBuilder:
             "#EXT-X-VERSION:7",
             "#EXT-X-PLAYLIST-TYPE:VOD",
             f"#EXT-X-TARGETDURATION:{int(target_dur_s) + 1}",
-            '#EXT-X-MAP:URI="init.mp4"',
+            '#EXT-X-MAP:URI="raw_init.mp4"',
         ]
         for s, dur_us in zip(segs, seg_durs_us):
             lines.append(f"#EXTINF:{dur_us / 1_000_000.0:.3f},")

--- a/app/services/lab/step_exporter.py
+++ b/app/services/lab/step_exporter.py
@@ -129,9 +129,9 @@ class StepExporter:
                 f"step_id={step_id} (all in-flight or playlist missing)"
             )
 
-        if not (step_dir / "init.mp4").exists():
+        if not (step_dir / f"{track}_init.mp4").exists():
             raise StepExportInitMissing(
-                f"init.mp4 not found for task {task_id} step {step_id}. "
+                f"{track}_init.mp4 not found for task {task_id} step {step_id}. "
                 "Historical segments must be migrated via "
                 "scripts/transcode_segments_to_h264.py before export."
             )
@@ -141,7 +141,7 @@ class StepExporter:
         output_path = self._temp_root / f"step_{task_id}_{step_id}_{track}_{nonce}.mp4"
 
         tmp_m3u8.write_text(
-            self._build_vod_text(segs, durations), encoding="utf-8"
+            self._build_vod_text(segs, durations, track), encoding="utf-8"
         )
         try:
             self._run_ffmpeg(tmp_m3u8, output_path, n_segments=len(segs))
@@ -164,7 +164,7 @@ class StepExporter:
     # -------- internal --------
 
     @staticmethod
-    def _build_vod_text(segs: List[SegmentRef], durations: dict) -> str:
+    def _build_vod_text(segs: List[SegmentRef], durations: dict, track: str) -> str:
         """构造喂给 ffmpeg 的 VOD m3u8 文本。
 
         段用 basename 引用 —— 该 m3u8 落在 step 目录，相对 URI 才解析得到
@@ -181,7 +181,7 @@ class StepExporter:
             "#EXT-X-PLAYLIST-TYPE:VOD",
             f"#EXT-X-TARGETDURATION:{target_duration}",
             "#EXT-X-MEDIA-SEQUENCE:0",
-            '#EXT-X-MAP:URI="init.mp4"',
+            f'#EXT-X-MAP:URI="{track}_init.mp4"',
         ]
         for s, dur in zip(segs, seg_durs):
             lines.append(f"#EXTINF:{dur:.3f},")

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -37,6 +37,22 @@ _EFF_FPS_MIN = 1.0
 _EFF_FPS_MAX = 60.0
 _DEGENERATE_FALLBACK_FPS = 15.0
 
+# fMP4 媒体时间基（mdhd.timescale，即 1 秒切成多少 tick），显式 pin 给 ffmpeg。
+#
+# 必须 pin 的理由：不指定时 ffmpeg 按 `fps 有理数的约分分子 × 2^k`（k 取到 ≥10000）自选
+# timescale，而 init.mp4 只由首段生成、被整条 playlist 复用（EXT-X-MAP 声明的就是它的
+# 时间基）。逐段 eff_fps 不同 → 逐段 timescale 不同 → 后续 fragment 的 tick 被按首段尺度
+# 解读，误差是乘性的：实测 15fps 定 init、14.37fps 段（其自选 timescale=11496）→ 声明
+# 10.02s 却被读成 7.60s，单段 2.4s 空洞，hls.js 段尾停摆。
+# 注意该自选值对 fps 极不连续——15.0→15360 但 14.37→11496（分子 1437 约不动），fps 抖 4%
+# 可致 timescale 差 25%，故「fps 波动不大就没事」不成立。
+#
+# 取 90000：MPEG-TS/RTP 标准视频时钟，能整除 30/25/24/20/15/12/10 等常见帧率（每帧分别
+# 3000/3600/3750/4500/6000/7500/9000 tick，无余数）；非整除帧率下 ffmpeg 按绝对 PTS 取整、
+# 增量差分得出，误差有界 ≤ 半 tick（5.6μs）且不累积。
+# pin 之后 timescale 与编码 fps 彻底解耦，逐段 eff_fps 才是合法的速率表达。
+_HLS_TIMESCALE = 90000
+
 
 class HLSPersistenceStrategy:
     """HLS持久化策略"""
@@ -93,10 +109,10 @@ class HLSPersistenceStrategy:
         """重启 supersede：删除 `{db_dir}/{task_id}/{step_id}` 整个 step 目录，返回是否删除。
 
         与 FeatureStore.open_fresh 对称——同 (task_id, step_id) 重启一次 run 前清空旧 HLS
-        产物（段 / *_playlist.m3u8 / metadata.json / init.mp4 / .hls_timescale 缓存），
-        否则新段带唯一时间戳文件名不覆盖旧段，只会往同一 playlist 里持续累计。
-        HLS 落盘全靠磁盘文件存在性驱动、无每目录内存态（playlist 首行、init.mp4、timescale
-        缓存均按 `exists()` 惰性重建），故 rmtree 后由后续首段自然重建，安全。
+        产物（段 / *_playlist.m3u8 / metadata.json / {track}_init.mp4），否则新段带唯一
+        时间戳文件名不覆盖旧段，只会往同一 playlist 里持续累计。
+        HLS 落盘全靠磁盘文件存在性驱动、无每目录内存态（playlist 首行、init 均按 `exists()`
+        惰性重建），故 rmtree 后由后续首段自然重建，安全。
         持该目录锁串行化，防极端在途 persist_segment 竞争——正常重启路径此刻已无活跃 worker
         （stop_run 已 flush 残段 + 出 registry + release_dir_locks）。
         """
@@ -212,64 +228,6 @@ class HLSPersistenceStrategy:
         return None
 
     @classmethod
-    def _read_timescale_from_init(cls, init_path: Path) -> Optional[int]:
-        """从 init.mp4 的 moov/trak/mdia/mdhd 读 timescale（赫兹）。
-
-        失败返回 None。fMP4 init segment 中仅有一个视频 trak，定位 path 固定。
-        """
-        try:
-            data = init_path.read_bytes()
-        except OSError as e:
-            logger.warning("[HLS] read init.mp4 failed (%s): %s", e, init_path)
-            return None
-        located = cls._find_box_path(
-            data, 0, len(data), (b"moov", b"trak", b"mdia", b"mdhd")
-        )
-        if located is None:
-            logger.warning("[HLS] mdhd not found in init.mp4: %s", init_path)
-            return None
-        body_start, body_end = located
-        # mdhd 结构：version(1) flags(3) 之后，version 0/1 决定 creation/modification/timescale/duration 宽度
-        if body_end - body_start < 4:
-            return None
-        version = data[body_start]
-        if version == 1:
-            ts_off = body_start + 4 + 8 + 8  # creation(8) + modification(8)
-            if body_end - body_start < 4 + 8 + 8 + 4:
-                return None
-        else:
-            ts_off = body_start + 4 + 4 + 4  # creation(4) + modification(4)
-            if body_end - body_start < 4 + 4 + 4 + 4:
-                return None
-        return struct.unpack(">I", data[ts_off : ts_off + 4])[0]
-
-    @classmethod
-    def _get_or_cache_timescale(cls, target_dir: Path) -> Optional[int]:
-        """读取 step dir 的 timescale；优先用 `.hls_timescale` 缓存文件，否则解析 init.mp4 并写缓存。
-
-        缓存文件单行十进制整数。解析失败 / init.mp4 缺失返回 None。
-        """
-        cache_path = target_dir / ".hls_timescale"
-        if cache_path.exists():
-            try:
-                txt = cache_path.read_text(encoding="utf-8").strip()
-                if txt.isdigit():
-                    return int(txt)
-            except OSError:
-                pass
-        init_path = target_dir / "init.mp4"
-        if not init_path.exists():
-            return None
-        ts = cls._read_timescale_from_init(init_path)
-        if ts is None or ts <= 0:
-            return None
-        try:
-            cache_path.write_text(str(ts), encoding="utf-8")
-        except OSError as e:
-            logger.warning("[HLS] write timescale cache failed (%s): %s", e, cache_path)
-        return ts
-
-    @classmethod
     def _patch_fragment_tfdt(cls, fragment_path: Path, base_media_decode_time: int) -> bool:
         """把 fmp4 fragment 的 moof/traf/tfdt.baseMediaDecodeTime 改写成指定值（单位=timescale tick）。
 
@@ -323,17 +281,22 @@ class HLSPersistenceStrategy:
         return True
 
     @classmethod
-    def _transcode_to_fmp4_segment(cls, path: Path) -> None:
-        """将 cv2 写出的 mp4v 段转码为 HLS-ready fMP4 fragment，并写入 step 级 init.mp4。
+    def _transcode_to_fmp4_segment(cls, path: Path, segment_type: str) -> None:
+        """将 cv2 写出的 mp4v 段转码为 HLS-ready fMP4 fragment，并写入 track 级 init.mp4。
 
-        Pipeline：cv2 mp4v → ffmpeg HLS muxer → init.mp4（首段）+ fMP4 fragment（原地替换）
-        → hex-patch tfdt.baseMediaDecodeTime 写入累计偏移。
+        Pipeline：cv2 mp4v → ffmpeg HLS muxer → {track}_init.mp4（首段）+ fMP4 fragment
+        （原地替换）→ hex-patch tfdt.baseMediaDecodeTime 写入累计偏移。
 
         - 普通 MP4（moov+mdat 整体）无法被 hls.js 在 m3u8 中作为段播放，会 fragParsingError
         - 改用 `-hls_segment_type fmp4` 让 ffmpeg 产出 init segment（ftyp+moov）+
           fragment（ftyp+moof+mdat），符合 HLS 协议要求
-        - init.mp4 每 step 一份共享：首次写入时落盘到 step 目录 + 缓存 timescale 到
-          `.hls_timescale`，已存在则丢弃产出物（同 step 同摄像头、同编码参数，SPS/PPS 一致）
+        - init 按 track 分开存 `{segment_type}_init.mp4`：raw 与 processed 是两条独立
+          playlist、各有各的 EXT-X-MAP，共用一个文件名会变成「谁先转码谁定」，另一条轨
+          就指向别人的 init。每 track 首次写入落盘，已存在则丢弃产出物（同 track 同摄像头、
+          同编码参数，SPS/PPS 一致）
+        - `-hls_segment_options video_track_timescale=` 把 mdhd.timescale pin 成
+          `_HLS_TIMESCALE`（理由见该常量注释）。注意必须走 `-hls_segment_options` 透传给
+          内层 mp4 muxer——直接给 hls muxer 传 `-video_track_timescale` 会被静默忽略
         - ffmpeg 子进程 cwd=target_dir + 输出全 basename：ffmpeg 4.x/8.x 对
           `-hls_fmp4_init_filename` 的绝对路径解析行为相反（4.x 拼到 playlist 目录前，
           8.x 拼到进程 cwd），只有「cwd=输出目录 + basename」在两个版本上都对
@@ -346,7 +309,7 @@ class HLSPersistenceStrategy:
         失败时保留 mp4v 原文件并打 warning，不抛异常 —— 主流程可用性优先。
         """
         target_dir = path.parent
-        init_path = target_dir / "init.mp4"
+        init_path = target_dir / f"{segment_type}_init.mp4"
         ts_offset = cls._ts_offset_seconds(path)
 
         stem = path.stem
@@ -385,6 +348,8 @@ class HLSPersistenceStrategy:
             # tfdt 偏移不在这里靠 -output_ts_offset 实现（ffmpeg 8.x HLS muxer + fmp4
             # 在 -start_number 0 下会清零 tfdt）—— 改成 transcode 完后 hex-patch tfdt box。
             "-hls_segment_type", "fmp4",
+            # 透传给内层 mp4 muxer：pin mdhd.timescale，切断「timescale 随编码 fps 变」
+            "-hls_segment_options", f"video_track_timescale={_HLS_TIMESCALE}",
             "-hls_fmp4_init_filename", tmp_init.name,
             "-hls_segment_filename", tmp_segment_template.name,
             "-start_number", "0",
@@ -418,14 +383,14 @@ class HLSPersistenceStrategy:
             _cleanup_tmp()
             return
 
-        # init.mp4 落盘：仅当 step 目录尚无 init 时
+        # init 落盘：仅当该 track 尚无 init 时
         if tmp_init.exists():
             if not init_path.exists():
                 try:
                     os.replace(tmp_init, init_path)
                 except OSError as e:
                     logger.warning(
-                        "[HLS] failed to install init.mp4 %s: %s", init_path, e
+                        "[HLS] failed to install init %s: %s", init_path, e
                     )
                     tmp_init.unlink(missing_ok=True)
             else:
@@ -443,17 +408,11 @@ class HLSPersistenceStrategy:
         # 临时 playlist 不再需要（由 persist_segment 自己维护）
         tmp_playlist.unlink(missing_ok=True)
 
-        # hex-patch tfdt：把累计 EXTINF（秒）→ timescale tick 写进 fragment 的 moof/traf/tfdt
-        # 没有 init.mp4 / timescale 读不到 → 跳过 patch，不影响首段（offset=0 本就正确）
+        # hex-patch tfdt：把累计 EXTINF（秒）→ tick 写进 fragment 的 moof/traf/tfdt。
+        # timescale 是 pin 死的常量，与 init.mp4 声明的必然一致，无需回读产物。
+        # 首段 offset=0，本就正确，跳过。
         if replaced and ts_offset > 0.0:
-            timescale = cls._get_or_cache_timescale(target_dir)
-            if timescale and timescale > 0:
-                cls._patch_fragment_tfdt(path, int(round(ts_offset * timescale)))
-            else:
-                logger.warning(
-                    "[HLS] timescale unavailable, tfdt patch skipped for %s (playback may stall)",
-                    path,
-                )
+            cls._patch_fragment_tfdt(path, int(round(ts_offset * _HLS_TIMESCALE)))
 
     def persist_segment(
         self, task_id: int, step_id: int, segment_type: str, frames: List[Frame]
@@ -549,9 +508,9 @@ class HLSPersistenceStrategy:
                             "#EXTM3U\n"
                             "#EXT-X-VERSION:7\n"
                             "#EXT-X-TARGETDURATION:10\n"
-                            '#EXT-X-MAP:URI="init.mp4"\n'
+                            '#EXT-X-MAP:URI="raw_init.mp4"\n'
                         )
-                self._transcode_to_fmp4_segment(raw_segment_path)
+                self._transcode_to_fmp4_segment(raw_segment_path, "raw")
                 with raw_playlist_path.open("a") as f:
                     f.write(f"#EXTINF:{segment_duration:.3f},\n{raw_segment_path.name}\n")
             except IOError as e:
@@ -643,9 +602,9 @@ class HLSPersistenceStrategy:
                             "#EXTM3U\n"
                             "#EXT-X-VERSION:7\n"
                             "#EXT-X-TARGETDURATION:10\n"
-                            '#EXT-X-MAP:URI="init.mp4"\n'
+                            '#EXT-X-MAP:URI="processed_init.mp4"\n'
                         )
-                self._transcode_to_fmp4_segment(segment_path)
+                self._transcode_to_fmp4_segment(segment_path, "processed")
                 with playlist_path.open("a") as f:
                     f.write(f"#EXTINF:{segment_duration:.3f},\n{segment_path.name}\n")
             except IOError as e:

--- a/app/services/persistence/strategies/hls_strategy.py
+++ b/app/services/persistence/strategies/hls_strategy.py
@@ -530,6 +530,8 @@ class HLSPersistenceStrategy:
                 timestamp=start_ts,
             )
 
+            self._update_timeline(target_dir, frames=frames)
+
         logger.info(
             "Raw segment已持久化: task_id=%s step_id=%s frames=%d duration=%.3fs",
             task_id,
@@ -687,3 +689,43 @@ class HLSPersistenceStrategy:
         # 写回文件
         with metadata_path.open("w", encoding="utf-8") as f:
             json.dump(metadata, f, ensure_ascii=False, indent=2)
+
+    def _update_timeline(self, target_dir: Path, frames: List[Frame]):
+        """把本段每帧的 ts 转成 tick 追加到 .timeline.idx / .timeline.log。
+
+        产出两个文件供 frame_tracker.py 离线回看使用：
+        - .timeline.idx：二进制 numpy structured array，dtype=[("tick", uint64)]，
+          每帧一条 tick 记录，按 raw 段落盘顺序追加。frame_tracker.Timeline 读它建
+          tick → frame_num 反查字典（frame_num = 文件中的记录序号）。
+        - .timeline.log：文本日志，每行 "ts tick"，人工排查用。
+
+        tick = int((ts - first_ts) * _HLS_TIMESCALE) — 与 frame_tracker.Timeline.frame_num_at
+        的 tick 公式完全一致（同 _HLS_TIMESCALE、同 first_ts 来源），保证索引查表命中。
+
+        只在 _persist_raw_segment 调用（不在 processed 调用）：离线推理回看只需 raw 帧。
+
+        持锁（由 _persist_raw_segment 的 _get_dir_lock 保护）：idx 是 append-only 的二进制
+        追加，不持锁多段并发会交错写、破坏 frame_num 与记录序号的对应关系。
+        """
+        metadata_path = target_dir / "metadata.json"
+        idx_path = target_dir / ".timeline.idx"
+        log_path = target_dir / ".timeline.log"
+
+        with metadata_path.open("r", encoding="utf-8") as f:
+            first_ts = json.load(f)["raw_segments"]["first_timestamp"]
+
+        ticks = []
+
+        with log_path.open("a") as log_f, open(idx_path, "ab") as idx_f:
+            for frame in frames:
+                ts = frame.timestamp
+                tick = int((ts - first_ts) * _HLS_TIMESCALE)
+                ticks.append(tick)
+                log_f.write(f"{ts} {tick}\n")
+
+            # numpy 局部 import：避免模块级引入（hls_strategy 不在其他路径用 np）
+            import numpy as np
+            data = np.core.records.fromarrays(
+                [np.array(ticks)], dtype=np.dtype([("tick", np.uint64)]),
+            )
+            data.tofile(idx_f)

--- a/docs/update/20260818_HLS_TIMELINE_INDEX.md
+++ b/docs/update/20260818_HLS_TIMELINE_INDEX.md
@@ -1,0 +1,61 @@
+# HLS Timeline 索引：ts → frame_num 反查 + ffmpeg 分块提取
+
+> **变更状态**：生效中（2026-08-18）
+> **知识库**：待沉淀
+
+## 概述
+
+- **改了什么**：raw 段落盘时同步写 `.timeline.idx`（二进制 numpy structured array，每帧一条 tick）+ `.timeline.log`（文本日志）；新增 [frame_tracker.py](../../app/services/inference/offline/frame_tracker.py) 读索引建 tick → frame_num 字典，用 ffmpeg `select=between(n)` 从 raw_playlist 按全局帧号分块提取帧。
+- **为什么**：离线推理需要按 records 的 ts 回看 HLS 落盘的原始帧。直接 seek fmp4 文件实现较为复杂，改用 tick → frame_num 索引反查，再调用 ffmpeg 按全局 frame_num 从 raw_playlist 切分块提取帧。
+- **影响面**：[hls_strategy.py `_update_timeline`](../../app/services/persistence/strategies/hls_strategy.py)（新增方法）、[frame_tracker.py](../../app/services/inference/offline/frame_tracker.py)（新文件）。
+
+## 原理
+
+### 索引的一致性锚点：tick
+
+两个组件通过同一个 tick 公式对齐：
+
+```
+tick = int((frame.ts - first_ts) * _HLS_TIMESCALE)
+```
+其中，`first_ts` 记录在 `metadata.json` 中，保持不变，作为 tick 基准。
+`_HLS_TIMESCALE` 作为 hls_strategy 中公共的 timescale，同样保持不变。
+
+- **写**（[_update_timeline](../../app/services/persistence/strategies/hls_strategy.py)）：每帧落盘时算 tick 追加到 `.timeline.idx`，记录序号 = frame_num（0-based 全局递增）。
+- **读**（[Timeline.frame_num_at](../../app/services/inference/offline/frame_tracker.py)）：给定 ts 算同一 tick，查字典得 frame_num。
+
+`_HLS_TIMESCALE` 在两个文件中各自定义同值 90000（[hls_strategy.py L54](../../app/services/persistence/strategies/hls_strategy.py)、[frame_tracker.py L13](../../app/services/inference/offline/frame_tracker.py)），与 cb9d473 pin 的 fMP4 `mdhd.timescale` 一致——tick 既是索引键，也是 fMP4 时间轴的单位，三套时间线（EXTINF / tfdt / timeline 索引）同源。
+
+### frame_num 的含义
+
+`.timeline.idx` 是 append-only 的二进制文件，每条记录的序号 = 该帧在整条 raw_playlist 中的全局帧号（从 0 起，跨段连续递增）。`Timeline._frame_nums` 建的是 `tick → 记录序号(frame_num)` 字典。
+
+### FrameCache 的分块策略
+
+[frame_tracker.FrameCache](../../app/services/inference/offline/frame_tracker.py) 按 `block_size=600` 帧分块，用 ffmpeg `select=between(n\,start\,end)` 从 raw_playlist 一次提取整块，LRU 缓存（capacity=10 块 = 6000 帧）。避免逐帧 seek 的 ffmpeg 进程启动开销；连续查询相邻帧时命中缓存。
+
+### 为什么只在 raw 段写索引
+
+`_update_timeline` 只在 `_persist_raw_segment` 调用：
+- 离线推理回看只需 raw 帧（processed 帧率不固定、帧号与 raw 不对齐）。
+- `FrameCache._extract_frames` 的 ffmpeg select 按 raw_playlist 的全局帧号提取。
+
+## 改动详情
+
+### 1. [hls_strategy.py `_update_timeline`](../../app/services/persistence/strategies/hls_strategy.py)
+
+新增方法，在 `_persist_raw_segment` 持锁块内调用（L533），紧跟 `_update_metadata` 之后：
+
+- 读 `metadata.json` 的 `raw_segments.first_timestamp` 作为 tick 基准。
+- 逐帧算 tick，追加到 `.timeline.idx`（numpy `dtype=[("tick", uint64)]`）和 `.timeline.log`（文本）。
+- 持锁保证 append-only 的记录序号与 frame_num 对应关系不被并发段交错破坏。
+
+### 2. [frame_tracker.py](../../app/services/inference/offline/frame_tracker.py)（新文件）
+
+三个类：
+
+- **Timeline**：读 `.timeline.idx` 建 `tick → frame_num` 字典；`frame_num_at(ts)` 算 tick 查表。
+- **FrameCache**：LRU + block 分块；`frame_at(ts, w, h)` → `frame_num` → `divmod(block_size)` → 按块提取/缓存 → 取 offset 帧。
+- **FrameTracker**：`find(records)` 逐条 ts → `Frame` 的迭代器，离线推理入口。
+
+`_extract_frames` 用 ffmpeg `-vf select=between(n\,start\,end) -vsync 0 -f rawvideo -pix_fmt bgr24 pipe:1`，从 raw_playlist.m3u8 按全局帧号范围提取，输出 rawvideo 到 pipe。

--- a/scripts/transcode_segments_to_h264.py
+++ b/scripts/transcode_segments_to_h264.py
@@ -1,16 +1,18 @@
 """
-批量升级历史 mp4 段为 HLS-ready fMP4 + 生成 step 级 init.mp4 + 重写 playlist 头
+批量升级历史 mp4 段为 HLS-ready fMP4 + 生成 track 级 init + 重写 playlist 头
 
 背景：
 - 早期段是 cv2 mp4v（MPEG-4 Part 2），后来升级为 H.264 普通 MP4 + faststart
 - 当前 hls.js 走 m3u8 播放时报 fragParsingError —— HLS 要求 MP4 段必须是 fragmented MP4
-- 本脚本把任意历史 mp4（mp4v / h264 普通 MP4）就地升级为 fMP4，并按 step 写一份共享
-  init.mp4，最后重写 m3u8 头（升 VERSION:7 + 插入 #EXT-X-MAP）
+- 本脚本把任意历史 mp4（mp4v / h264 普通 MP4）就地升级为 fMP4，并按 track 写
+  `{track}_init.mp4`，最后重写 m3u8 头（升 VERSION:7 + 插入 #EXT-X-MAP）
 
 策略：
 - 按 step 目录维度迁移（外层 task_id，内层 step_id）
-- 同 step 内所有段共享一份 init.mp4：第一个段产出时落盘，后续段产出的 init 丢弃
-- 幂等：step 目录已存在 init.mp4 且 playlist 已含 #EXT-X-MAP 则跳过（除非 --force）
+- 同 track 内所有段共享一份 `{track}_init.mp4`：该 track 第一个段产出时落盘，后续丢弃。
+  raw / processed 各一份——两条独立 playlist 各有各的 EXT-X-MAP，共用会指错时间基
+- timescale pin 成 hls_strategy._HLS_TIMESCALE，与新段路径同一时间基
+- 幂等：两份 init 都在且 playlist 已含 #EXT-X-MAP 则跳过（除非 --force）
 - 单段失败仅 WARN 并继续，不中断批次
 
 用法：
@@ -31,6 +33,8 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+from app.services.persistence.strategies.hls_strategy import _HLS_TIMESCALE
 
 logger = logging.getLogger("transcode_segments")
 
@@ -252,6 +256,8 @@ def _transcode_segment_to_fmp4(
         "-an",
         "-output_ts_offset", f"{effective_offset:.6f}",
         "-hls_segment_type", "fmp4",
+        # 与 hls_strategy 写新段路径 pin 同一个 timescale，否则迁移产物与新段的时间基不同
+        "-hls_segment_options", f"video_track_timescale={_HLS_TIMESCALE}",
         # 必须用绝对路径：ffmpeg 8.x 的 HLS muxer 把此处的 basename 解析到进程 cwd
         # 而不是 playlist 输出目录。详见 hls_strategy.py 同名注释。
         "-hls_fmp4_init_filename", str(tmp_init),
@@ -349,6 +355,7 @@ def _playlist_already_fmp4(path: Path) -> bool:
 
 def _rewrite_playlist_header(
     path: Path,
+    track: str,
     durations: Optional[Dict[str, float]] = None,
 ) -> bool:
     """把旧头部重写为 VERSION:7 + EXT-X-MAP，并以 durations 覆盖 EXTINF。
@@ -378,7 +385,7 @@ def _rewrite_playlist_header(
         "#EXTM3U",
         "#EXT-X-VERSION:7",
         f"#EXT-X-TARGETDURATION:{target_duration}",
-        '#EXT-X-MAP:URI="init.mp4"',
+        f'#EXT-X-MAP:URI="{track}_init.mp4"',
     ]
     for dur, fname in new_entries:
         lines.append(f"#EXTINF:{dur:.3f},")
@@ -438,12 +445,14 @@ def _migrate_step(
     - 转码完成后把探测出的 duration 累加到 cumulative
     - 最后用 durations 表覆盖 playlist 的 EXTINF —— 三套时间线对齐
     """
-    init_path = step_dir / "init.mp4"
+    # init 按 track 分开：raw / processed 是两条独立 playlist，各有各的 EXT-X-MAP，
+    # 共用一份会变成「谁先转码谁定」，另一条轨就指向别人的 init。与 hls_strategy 一致。
+    init_paths = {t: step_dir / f"{t}_init.mp4" for t in ("raw", "processed")}
     raw_playlist = step_dir / "raw_playlist.m3u8"
     proc_playlist = step_dir / "processed_playlist.m3u8"
 
     already_migrated = (
-        init_path.exists()
+        all(p.exists() for p in init_paths.values())
         and (not raw_playlist.exists() or _playlist_already_fmp4(raw_playlist))
         and (not proc_playlist.exists() or _playlist_already_fmp4(proc_playlist))
     )
@@ -467,8 +476,9 @@ def _migrate_step(
     if dry_run:
         for seg in segments:
             logger.info("[dry-run] would transcode %s", seg.relative_to(base_dir))
-        if not init_path.exists():
-            logger.info("[dry-run] would create %s", init_path.relative_to(base_dir))
+        for p in init_paths.values():
+            if not p.exists():
+                logger.info("[dry-run] would create %s", p.relative_to(base_dir))
         for pl in (raw_playlist, proc_playlist):
             if pl.exists():
                 logger.info("[dry-run] would rewrite header+EXTINF %s", pl.relative_to(base_dir))
@@ -478,13 +488,14 @@ def _migrate_step(
     raw_segs = [s for s in segments if _track_of(s) == "raw"]
     proc_segs = [s for s in segments if _track_of(s) == "processed"]
 
-    # init 没产出过就让第一个段去捕获
-    init_already = init_path.exists()
     converted = 0
     failed = 0
     durations_by_track: Dict[str, Dict[str, float]] = {"raw": {}, "processed": {}}
 
     for track_name, track_segs in (("raw", raw_segs), ("processed", proc_segs)):
+        init_path = init_paths[track_name]
+        # 该 track 的 init 没产出过就让它的第一个段去捕获
+        init_already = init_path.exists()
         cumulative = 0.0
         for seg in track_segs:
             # 传入 init_path 让 --force 重跑场景能拼接探测 fMP4 fragment
@@ -514,12 +525,12 @@ def _migrate_step(
                 failed += 1
 
     # 重写 playlist：无条件覆盖 EXTINF（新公式 = 探测出的 fragment 媒体时长）
-    for pl, durations in (
-        (raw_playlist, durations_by_track["raw"]),
-        (proc_playlist, durations_by_track["processed"]),
+    for pl, track_name, durations in (
+        (raw_playlist, "raw", durations_by_track["raw"]),
+        (proc_playlist, "processed", durations_by_track["processed"]),
     ):
         if pl.exists():
-            ok = _rewrite_playlist_header(pl, durations=durations)
+            ok = _rewrite_playlist_header(pl, track_name, durations=durations)
             logger.info(
                 "[playlist %s] %s",
                 "rewritten" if ok else "rewrite-failed",

--- a/tests/test_lab_clip_builder.py
+++ b/tests/test_lab_clip_builder.py
@@ -40,7 +40,7 @@ def _make_step_with_segments(
     for ts in segs_ts_us:
         (step_dir / f"raw_segment_{ts}.mp4").write_bytes(b"fake-fmp4")
     if with_init:
-        (step_dir / "init.mp4").write_bytes(b"fake-init")
+        (step_dir / "raw_init.mp4").write_bytes(b"fake-init")
     return step_dir
 
 
@@ -106,7 +106,7 @@ class TestRunFfmpegM3u8:
         text = captured["m3u8_text"]
         assert "#EXTM3U" in text
         assert "#EXT-X-VERSION:7" in text
-        assert '#EXT-X-MAP:URI="init.mp4"' in text
+        assert '#EXT-X-MAP:URI="raw_init.mp4"' in text
         # 段以 basename 出现（相对 URI，依赖临时 m3u8 与段同目录）
         assert f"raw_segment_{ts0}.mp4" in text
         assert f"raw_segment_{ts1}.mp4" in text

--- a/tests/test_lab_step_exporter.py
+++ b/tests/test_lab_step_exporter.py
@@ -58,7 +58,7 @@ def _make_step(
     for ts in segs_ts_us:
         (step_dir / f"{track}_segment_{ts}.mp4").write_bytes(b"fake-fmp4")
     if with_init:
-        (step_dir / "init.mp4").write_bytes(b"fake-init")
+        (step_dir / f"{track}_init.mp4").write_bytes(b"fake-init")
 
     in_playlist = segs_ts_us if playlist_ts is None else playlist_ts
     durs = durations or [10.0] * len(in_playlist)
@@ -66,7 +66,7 @@ def _make_step(
         "#EXTM3U",
         "#EXT-X-VERSION:7",
         "#EXT-X-TARGETDURATION:10",
-        '#EXT-X-MAP:URI="init.mp4"',
+        f"#EXT-X-MAP:URI={track}_init.mp4",
     ]
     for ts, d in zip(in_playlist, durs):
         lines.append(f"#EXTINF:{d:.3f},")
@@ -127,7 +127,7 @@ class TestVodPlaylist:
         assert "#EXTM3U" in text
         assert "#EXT-X-VERSION:7" in text
         assert "#EXT-X-PLAYLIST-TYPE:VOD" in text
-        assert '#EXT-X-MAP:URI="init.mp4"' in text
+        assert '#EXT-X-MAP:URI="raw_init.mp4"' in text
         # 段以 basename 出现（相对 URI，依赖临时 m3u8 与段同目录）
         assert f"raw_segment_{TS0}.mp4" in text
         assert f"raw_segment_{TS1}.mp4" in text

--- a/tests/test_traceback_router.py
+++ b/tests/test_traceback_router.py
@@ -35,11 +35,11 @@ def _seed_task(base_dir: Path, task_id: int, step_id: int, ts_us_list, write_ini
     d.mkdir(parents=True, exist_ok=True)
     raw_pl_lines = [
         "#EXTM3U", "#EXT-X-VERSION:7", "#EXT-X-TARGETDURATION:10",
-        '#EXT-X-MAP:URI="init.mp4"',
+        '#EXT-X-MAP:URI="raw_init.mp4"',
     ]
     proc_pl_lines = [
         "#EXTM3U", "#EXT-X-VERSION:7", "#EXT-X-TARGETDURATION:10",
-        '#EXT-X-MAP:URI="init.mp4"',
+        '#EXT-X-MAP:URI="processed_init.mp4"',
     ]
     for ts_us in ts_us_list:
         (d / f"raw_segment_{ts_us}.mp4").write_bytes(b"\x00" * 16)
@@ -51,7 +51,8 @@ def _seed_task(base_dir: Path, task_id: int, step_id: int, ts_us_list, write_ini
     (d / "raw_playlist.m3u8").write_text("\n".join(raw_pl_lines) + "\n")
     (d / "processed_playlist.m3u8").write_text("\n".join(proc_pl_lines) + "\n")
     if write_init:
-        (d / "init.mp4").write_bytes(b"\x00" * 8)
+        (d / "raw_init.mp4").write_bytes(b"\x00" * 8)
+        (d / "processed_init.mp4").write_bytes(b"\x00" * 8)
     return d
 
 
@@ -440,10 +441,10 @@ async def test_media_segment_missing_file_returns_404(client, media_root):
 @pytest.mark.asyncio
 async def test_media_init_with_valid_token(client, media_root):
     d = _seed_task(media_root, task_id=10, step_id=1, ts_us_list=[1_000_000])
-    expected = (d / "init.mp4").read_bytes()
+    expected = (d / "raw_init.mp4").read_bytes()
 
     token = MediaToken.default().sign(
-        task_id=10, step_id=1, filename="init.mp4", kind="init",
+        task_id=10, step_id=1, filename="raw_init.mp4", kind="init",
     )
     resp = await client.get(f"/media/init/{token}")
     assert resp.status_code == 200


### PR DESCRIPTION
#### 变更概述

本次 PR 修改了当前 HLS 存储策略：
+ 固定 timescale = 90000；
+ 同一 step 目录下两条轨各自维护 `raw_init.mp4` / `processed_init.mp4`，不再共用 `init.mp4`；
+ 新增了HLS时间线索引生成，用于支持离线推理时原始帧回看提取功能。


#### 变更内容

+ `app/services/persistence/strategies/hls_strategy.py`： HLS timescale 固定为 `_HLS_TIMESCALE = 90000`； 新增方法 `_update_timeline` ，维护原始帧时间戳→ticks映射关系，用于离线反查。
+ `app/services/inference/offline/frame_tracker.py`：根据索引文件和特征落盘记录，返回原始帧。
+ `app/routers/media.py`, `app/routers/traceback.py`, `app/services/lab/clip_builder.py`, `app/services/lab/step_exporter.py`：修改 `init.mp4` 为 `{track}_init.mp4`
+ `tests/test_lab_clip_builder.py`, `tests/test_lab_step_exporter.py`, `tests/test_traceback_router.py`：修改 `init.mp4` 为 `{track}_init.mp4`

#### 自测情况

`python -m pytest tests/` 测试全部通过

本地模拟 raw 和 processed 实时视频流落盘，离线调用 `FrameTracker.find()` 对特征落盘记录查询，可以得到相应原始帧且图像内容一致，认为反查恢复功能实现正确。